### PR TITLE
Add translation helper for widgets

### DIFF
--- a/analogic/static/assets/js/framework/utils.js
+++ b/analogic/static/assets/js/framework/utils.js
@@ -1,4 +1,4 @@
-/* global Api, app, El, Doc, Intl, Widgets, WidgetState */
+/* global Api, app, El, Doc, Intl, Widgets, WidgetState, translations */
 
 'use strict';
 const L = console.log,
@@ -35,6 +35,7 @@ const Utils = {
         'í': 'i'
     }),
     clone: (object, deep, isObject = true) => deep ? $.extend(true, isObject ? {} : [], object) : $.extend(isObject ? {} : [], object),
+    translate: s => (typeof translations !== 'undefined' && translations[s]) ? translations[s] : s,
     replaceAll: (s, m) => s.replace(RegExp(Object.keys(m).join('|'), 'gi'), r => m[r.toLowerCase()]),
     scrollTop: duration => $('html, body').animate({scrollTop: 0}, duration || 500),
     scrollTo(idOrObj, duration, topOffset = 0) {

--- a/analogic/static/assets/js/widgets/button.js
+++ b/analogic/static/assets/js/widgets/button.js
@@ -1,4 +1,4 @@
-/* global app, El, Widget */
+/* global app, El, Widget, Utils */
 
 'use strict';
 
@@ -63,12 +63,12 @@ class ButtonWidget extends Widget {
         this.setValues(d, v);
 
         return `
-<a style="${aStyle.join('')}" ${o.confirmMessage2 ? `data-confirmmessage2="${o.confirmMessage2}" ` : ''} ${o.confirmMessage ? `data-confirmmessage="${o.confirmMessage}" ` : ''} ${v.url ? `target="_blank" href="${v.url}" data-id="${o.id}" data-action="${v.paste ? "launchpaste" : "launch"}" ` : `data-id="${o.id}" data-action="${v.paste ? "launchpaste" : "launch"}"`} class="ks-button ${aClass.join(' ')} ks-button-${v.skin} ">
+<a style="${aStyle.join('')}" ${o.confirmMessage2 ? `data-confirmmessage2="${Utils.translate(o.confirmMessage2)}" ` : ''} ${o.confirmMessage ? `data-confirmmessage="${Utils.translate(o.confirmMessage)}" ` : ''} ${v.url ? `target="_blank" href="${v.url}" data-id="${o.id}" data-action="${v.paste ? "launchpaste" : "launch"}" ` : `data-id="${o.id}" data-action="${v.paste ? "launchpaste" : "launch"}"`} class="ks-button ${aClass.join(' ')} ks-button-${v.skin} ">
     <div class="ks-button-inner" style="${innerStyle.join('')}">
         <div class="ks-button-content" style="${contentStyle.join('')}">
             <div class="ks-button-icon" style="${iconStyle.join('')}">${v.icon !== false ? iconInfo.html : ''}</div>
             <div class="ks-button-divider" style="${dividerStyle.join('')}"></div>
-            <div class="ks-button-label" title="${Utils.htmlEncode(v.label)}" style="${labelStyle.join('')}">${v.label}</div>
+            <div class="ks-button-label" title="${Utils.htmlEncode(Utils.translate(v.label))}" style="${labelStyle.join('')}">${Utils.translate(v.label)}</div>
         </div>
     </div>
 </a>`;
@@ -160,7 +160,7 @@ class ButtonWidget extends Widget {
         //label
 
         if (v.label !== '') {
-            labelDiv.html(v.label);
+            labelDiv.html(Utils.translate(v.label));
             !main.hasClass('has-label') && main.addClass('has-label');
         } else {
             labelDiv.html('');

--- a/analogic/static/assets/js/widgets/datepicker.js
+++ b/analogic/static/assets/js/widgets/datepicker.js
@@ -1,4 +1,4 @@
-/* global app, Doc, Widget, Widgets */
+/* global app, Doc, Widget, Widgets, Utils */
 
 'use strict';
 
@@ -65,12 +65,12 @@ class DatePickerWidget extends Widget {
 <div class="ks-datepicker dropdown-type ks-datepicker-${v.skin}" style="${mainDivStyle.join('')}" data-ordinal="${v.ordinal}" data-monthpicker="${v.monthPicker || false}" data-min-date="${v.minDate || ''}" data-max-date="${v.maxDate || ''}">
     <div class="ks-datepicker-inner" style="${innerStyle.join('')}">
         <div class="ks-datepicker-title"  style="${titleStyles.join('')}">
-            ${v.titleVisible ? v.title : ''}
+            ${v.titleVisible ? Utils.translate(v.title) : ''}
         </div>
         <div class="ks-datepicker-field">
             <div class="ks-datepicker-field-inner">
                 <div class="ks-datepicker-icon icon-date"></div>
-                <input type="text" class="ks-datepicker-input" placeholder="Choose..." value="${dateText}" ${v.editable ? '' : `disabled`}>
+                <input type="text" class="ks-datepicker-input" placeholder="${Utils.translate('Choose...')}" value="${dateText}" ${v.editable ? '' : `disabled`}>
             </div>
         </div>
     </div>
@@ -83,7 +83,7 @@ class DatePickerWidget extends Widget {
                 <div class="ks-datepicker-panel-pager ks-right"></div>
             </div>
         </div>
-        <div class="ks-datepicker-full-year-button" ${v.fullYearButtonVisible ? '' : 'style="display:none;"'}>${v.fullYearButtonText}</div>
+        <div class="ks-datepicker-full-year-button" ${v.fullYearButtonVisible ? '' : 'style="display:none;"'}>${Utils.translate(v.fullYearButtonText)}</div>
         <div class="ks-datepicker-panel-months" >${monthsHtml.join('')}</div>
         <div class="ks-datepicker-panel-days" ${v.monthPicker ? 'style="display:none;"' : ''}>${v.monthPicker ? '' : DatePickerWidget.getPickerHolderDaysHtml(date, minDate, maxDate)}</div>
     </div>` : ''}

--- a/analogic/static/assets/js/widgets/dropbox.js
+++ b/analogic/static/assets/js/widgets/dropbox.js
@@ -1,4 +1,4 @@
-/* global app, Doc, Widget, Widgets */
+/* global app, Doc, Widget, Widgets, Utils */
 
 'use strict';
 
@@ -31,12 +31,12 @@ class DropBoxWidget extends Widget {
 <div class="ks-dropbox ks-dropbox-${v.skin}" style="${mainDivStyle.join('')}">
     <div class="ks-dropbox-inner">
         <div class="ks-dropbox-title" style="${titleStyles.join('')}">
-            <span class="ks-dropbox-title-primary">${v.titleVisible ? v.title : ''}</span>
+            <span class="ks-dropbox-title-primary">${v.titleVisible ? Utils.translate(v.title) : ''}</span>
             <span class="ks-dropbox-title-secondary"></span>
         </div>
         <div class="ks-dropbox-field ${v.editable === false ? 'readonly' : ''}">
             <div class="ks-dropbox-field-inner">
-                <input ${v.editable === false || v.disableSearch === true  ? 'readonly' : ''} style="${textStyles.join('')}" type="text" class="ks-dropbox-input search-text" placeholder="${pi.selectedItems !== '' ? pi.selectedItems : v.placeHolder}">
+                <input ${v.editable === false || v.disableSearch === true  ? 'readonly' : ''} style="${textStyles.join('')}" type="text" class="ks-dropbox-input search-text" placeholder="${Utils.translate(pi.selectedItems !== '' ? pi.selectedItems : v.placeHolder)}">
                 <div class="ks-dropbox-icon"></div>
             </div>
         </div>
@@ -74,7 +74,7 @@ class DropBoxWidget extends Widget {
         this.value = data.value;
         this.items = data.items;
 
-        let selectedItems = selectedItemsArray.map(item => item.name).join(', ');
+        let selectedItems = selectedItemsArray.map(item => Utils.translate(item.name)).join(', ');
 
         return {
           selectedItems: selectedItems,
@@ -89,10 +89,10 @@ class DropBoxWidget extends Widget {
     <div class="ks-dropbox-panel-item-inner">
         <div class="ks-dropbox-panel-item-icon">
            <span></span>
-            <input class="ks-dropbox-panel-item-checkbox" ${v.multiSelect ? '' : 'style="display:none;"'} ${item.on ? 'checked=checked' : ''} type="checkbox">
+            <input class="ks-dropbox-panel-item-checkbox" ${v.multiSelect ? '' : 'style=\"display:none;\"'} ${item.on ? 'checked=checked' : ''} type="checkbox">
         </div>
         <div class="ks-dropbox-panel-item-separator"></div>
-        <div class="ks-dropbox-panel-item-text" style="white-space: nowrap;overflow: hidden;text-overflow: ellipsis;" title="${item.name}">${item.name}</div>
+        <div class="ks-dropbox-panel-item-text" style="white-space: nowrap;overflow: hidden;text-overflow: ellipsis;" title="${Utils.htmlEncode(Utils.translate(item.name))}">${Utils.translate(item.name)}</div>
     </div>
 </div>`;
         }).join('');
@@ -134,7 +134,7 @@ class DropBoxWidget extends Widget {
         } else {
             const pi = this.processItems(data, this.options, p);
             inner.html(this.getItems(pi.data, p));
-            input.attr('placeholder', pi.selectedItems !== '' ? pi.selectedItems : p.placeHolder);
+            input.attr('placeholder', pi.selectedItems !== '' ? pi.selectedItems : Utils.translate(p.placeHolder));
         }
     }
 
@@ -235,7 +235,7 @@ class DropBoxWidget extends Widget {
             itemHolder.slideUp(50);
         }
 
-        let v = $.grep(w.items, (item, i) => item.on).map(item => item.name).join(', '),
+        let v = $.grep(w.items, (item, i) => item.on).map(item => Utils.translate(item.name)).join(', '),
             searchText = $('#' + id + ' .search-text');
 
         (!state.serverSideFilter || !state.multiSelect) && searchText.attr('placeholder', v).val('');

--- a/analogic/static/assets/js/widgets/horizontal-table.js
+++ b/analogic/static/assets/js/widgets/horizontal-table.js
@@ -29,7 +29,7 @@ class HorizontalTableWidget extends Widget {
         }
 
         if (v.searchField) {
-            s.push(`<div class="ks-horizontal-table-search"><div class="ks-horizontal-table-search-icon"><span class="icon-search"></span></div><input type="text" value=" ${withState && this.state.searchInput ? this.state.searchInput : ''}" class="ks-horizontal-table-search-input" placeholder="Search..."></div>`);
+            s.push(`<div class="ks-horizontal-table-search"><div class="ks-horizontal-table-search-icon"><span class="icon-search"></span></div><input type="text" value=" ${withState && this.state.searchInput ? this.state.searchInput : ''}" class="ks-horizontal-table-search-input" placeholder="${Utils.translate('Search...')}"></div>`);
         }
 
         if (o.checkbox) {
@@ -38,7 +38,7 @@ class HorizontalTableWidget extends Widget {
     <div class="ks-horizontal-table-search-toggle ${withState && this.state.checkbox === true ? 'ks-on' : ''}" data-value="${o.checkbox.value}">
         <div class="ks-horizontal-table-toggle-icon ks-horizontal-table-toggle-icon-off"><span class="icon-checkbox-off"></span></div>
         <div class="ks-horizontal-table-toggle-icon ks-horizontal-table-toggle-icon-on"><span class="icon-checkbox-on"></span></div>
-        <div class="ks-horizontal-table-toggle-label ks-horizontal-table-toggle-label-on">${o.checkbox.value} Only</div>
+        <div class="ks-horizontal-table-toggle-label ks-horizontal-table-toggle-label-on">${Utils.translate(o.checkbox.value)} ${Utils.translate('Only')}</div>
     </div>
 </div>`
             );
@@ -72,7 +72,7 @@ class HorizontalTableWidget extends Widget {
             <div class="ks-horizontal-table-body-scroll" style="max-height:${fadeOutHeight}px;${data.cells.length <= v.fadeOutNum ? 'overflow:hidden;' : ''}">${d}</div>
             ${data.cells.length > v.fadeOutNum ? '<div class="ks-horizontal-table-fade"></div>' : ''}
         </div>
-        ${data.cells.length > v.fadeOutNum ? `<div class="ks-horizontal-table-footer"><div class="ks-horizontal-table-info">${data.cells.length}  ${data.cells.length > 1 ? 'results' : 'result'}</div></div>` : ''}
+        ${data.cells.length > v.fadeOutNum ? `<div class="ks-horizontal-table-footer"><div class="ks-horizontal-table-info">${data.cells.length}  ${Utils.translate(data.cells.length > 1 ? 'results' : 'result')}</div></div>` : ''}
     </div>
 </div>`;
     }
@@ -82,20 +82,20 @@ class HorizontalTableWidget extends Widget {
 
         if (data.leftActionCells.length > 0) {
             for (l of data.leftActionCells[0]) {
-                s.push(`<div class="ks-horizontal-table-cell ks-${leftRowWidgets[i].name === 'RadioButtonRowWidget' ? 'checkbox' : 'action'}-cell" ${actionWidth !== false ? `style="flex: 0 0 ${actionWidth}%;"` : ''}>${leftRowWidgets[i].options.columnName ? leftRowWidgets[i].options.columnName : ''}</div>`);
+                s.push(`<div class="ks-horizontal-table-cell ks-${leftRowWidgets[i].name === 'RadioButtonRowWidget' ? 'checkbox' : 'action'}-cell" ${actionWidth !== false ? `style="flex: 0 0 ${actionWidth}%;"` : ''}>${leftRowWidgets[i].options.columnName ? Utils.translate(leftRowWidgets[i].options.columnName) : ''}</div>`);
                 ++i;
             }
         }
 
         for (const [ind, vi] of o.columnNames.entries()) {
-            s.push(`<div class="ks-horizontal-table-cell sortable" style="${o.columnWidths && o.columnWidths[ind] && parseInt(o.columnWidths[ind].replace('%', '')) === 0 ? 'display:none;' : ''}${o.columnWidths && o.columnWidths[ind] ? 'flex: 0 0 ' + o.columnWidths[ind] + (o.columnWidths[ind].indexOf('%') === -1 ? 'px;' : ';') : ''}"><div class="ks-horizontal-table-cell-inner">${vi}<div class="ks-order"></div></div></div>`);
+            s.push(`<div class="ks-horizontal-table-cell sortable" style="${o.columnWidths && o.columnWidths[ind] && parseInt(o.columnWidths[ind].replace('%', '')) === 0 ? 'display:none;' : ''}${o.columnWidths && o.columnWidths[ind] ? 'flex: 0 0 ' + o.columnWidths[ind] + (o.columnWidths[ind].indexOf('%') === -1 ? 'px;' : ';') : ''}"><div class="ks-horizontal-table-cell-inner">${Utils.translate(vi)}<div class="ks-order"></div></div></div>`);
             dataColumnNames.push(vi.toLowerCase().replace(/[&\/\\#, +()$~%.'":*?<>{}]/g, ''));
         }
 
         if (data.rightActionCells.length > 0) {
             i = 0;
             for (l of data.rightActionCells[0]) {
-                s.push(`<div class="ks-horizontal-table-cell ks-${rightRowWidgets[i].name === 'RadioButtonRowWidget' ? 'checkbox' : 'action'}-cell"  ${actionWidth !== false ? `style="flex: 0 0 ${actionWidth}%;"` : ''}>${rightRowWidgets[i].options.columnName ? rightRowWidgets[i].options.columnName : ''}</div>`);
+                s.push(`<div class="ks-horizontal-table-cell ks-${rightRowWidgets[i].name === 'RadioButtonRowWidget' ? 'checkbox' : 'action'}-cell"  ${actionWidth !== false ? `style="flex: 0 0 ${actionWidth}%;"` : ''}>${rightRowWidgets[i].options.columnName ? Utils.translate(rightRowWidgets[i].options.columnName) : ''}</div>`);
                 ++i;
             }
         }

--- a/analogic/static/assets/js/widgets/image-upload.js
+++ b/analogic/static/assets/js/widgets/image-upload.js
@@ -1,4 +1,4 @@
-/* global app, Widget, Widgets */
+/* global app, Widget, Widgets, Api, Utils */
 
 'use strict';
 
@@ -36,7 +36,7 @@ class ImageUploadWidget extends Widget {
 
         this.maxFileSize = params.maxFileSize;
         this.maxFileSizePerFile = params.maxFileSizePerFile;
-        this.uploadSuccessMessage = params.uploadSuccessMessage;
+        this.uploadSuccessMessage = Utils.translate(params.uploadSuccessMessage);
         this.showUploadSuccessMessage = params.showUploadSuccessMessage;
         this.skipStoppingTheLoaderAfterSuccessUpload = params.skipStoppingTheLoaderAfterSuccessUpload;
         this.allowedMimeTypes = params.allowedMimeTypes;
@@ -103,7 +103,7 @@ class ImageUploadWidget extends Widget {
                 <input style="opacity: 0;width: 0.1px;height: 0.1px;" data-id="${o.id}" data-action="uploadImage" type="file" multiple>
                 <div class="ks-button-icon" style="${imgStyle.join('')}">${params.icon !== false ? `<span style="${imgStyle.join('')}" class="${params.icon}"></span>` : ''}</div>
                 <div class="ks-button-divider" style="${dividerStyle.join('')}"></div>
-                <div class="ks-button-label" style="${labelStyle.join('')}">${params.label}</div>
+                <div class="ks-button-label" style="${labelStyle.join('')}">${Utils.translate(params.label)}</div>
             </div>
         </div>
     </label>
@@ -122,7 +122,7 @@ class ImageUploadWidget extends Widget {
                 file = files[i];
 
                 if (file.size / 1048576 > mf) {
-                    Api.showPopup('Maximum file size per file: ' + mf + ' mb!');
+                    Api.showPopup(Utils.translate('Maximum file size per file:') + ' ' + mf + ' mb!');
                     s.val('');
                     return;
                 }
@@ -130,7 +130,7 @@ class ImageUploadWidget extends Widget {
                 size += file.size;
 
                 if (amt && !amt.includes(file.type)) {
-                    Api.showPopup('Only ' + amt.join(',') + ' files are allowed!');
+                    Api.showPopup(Utils.translate('Only') + ' ' + amt.join(',') + ' ' + Utils.translate('files are allowed!'));
                     s.val('');
                     return;
                 }
@@ -138,7 +138,7 @@ class ImageUploadWidget extends Widget {
                 if (aw && ah) {
                     let valid = await ww.validateImageDimensions(file, 640, 360);
                     if (!valid) {
-                        Api.showPopup('Image dimensions must be ' + aw + 'x' + ah + ' pixels!');
+                        Api.showPopup(Utils.translate('Image dimensions must be') + ' ' + aw + 'x' + ah + ' ' + Utils.translate('pixels!'));
                         s.val('');
                         return;
                     }
@@ -164,7 +164,7 @@ class ImageUploadWidget extends Widget {
 
                 Widget.doHandleSystemEvent(s, e);
             } else {
-                Api.showPopup('The maximum size of all files: ' + m + ' mb!');
+                Api.showPopup(Utils.translate('The maximum size of all files:') + ' ' + m + ' mb!');
 
                 s.val('');
             }

--- a/analogic/static/assets/js/widgets/image.js
+++ b/analogic/static/assets/js/widgets/image.js
@@ -1,4 +1,4 @@
-/* global app, Widget */
+/* global app, Widget, Utils */
 
 'use strict';
 
@@ -17,7 +17,7 @@ class ImageWidget extends Widget {
         if (o.icon) {
             html.push(`<span class="icon-${v.icon}" style="display: inline-block;${s.join('')}"><\/span>`);
         } else {
-            html.push('<img src="' + app.applicationAssetsUrl + '/skin/images/' + v.fileName + '" alt="' + v.title + '" style="' + s.join('') + '">');
+            html.push('<img src="' + app.applicationAssetsUrl + '/skin/images/' + v.fileName + '" alt="' + Utils.translate(v.title) + '" style="' + s.join('') + '">');
         }
         html.push('</div>');
 

--- a/analogic/static/assets/js/widgets/page.js
+++ b/analogic/static/assets/js/widgets/page.js
@@ -1,10 +1,11 @@
+/* global Utils */
 'use strict';
 
 class PageWidget extends Widget {
 
     getHtml(widgets, d) {
         const params = this.getParameters(d);
-        this.title = params.title;
+        this.title = Utils.translate(params.title);
         this.favicon = params.favicon;
 
         return widgets.join('');

--- a/analogic/static/assets/js/widgets/pivot-table.js
+++ b/analogic/static/assets/js/widgets/pivot-table.js
@@ -1,3 +1,4 @@
+/* global Utils, Widget, Widgets, Repository, Pivot, LoadExecutorFactory */
 class PivotTableWidget extends Widget {
 
 
@@ -27,8 +28,8 @@ class PivotTableWidget extends Widget {
         const o = this.options;
 
         this.lastSelectionSubset = 'user_Default';
-        this.lastSelectionDisplayName = 'Last selection';
-        this.selectorTreeColNames = ['Dimensions', 'Hierarchies', 'Subsets', 'Elements'];
+        this.lastSelectionDisplayName = Utils.translate('Last selection');
+        this.selectorTreeColNames = [Utils.translate('Dimensions'), Utils.translate('Hierarchies'), Utils.translate('Subsets'), Utils.translate('Elements')];
         this.colors = [{name: 'Light Blue 100', hex: '009FDA'}, {
             name: 'Light Blue 60',
             hex: '66C5E9'
@@ -74,38 +75,38 @@ class PivotTableWidget extends Widget {
             <div class="ks-pivot-table-presets-btn">
                 <span class="icon-ellipsis"></span>
                 <div id="pivotPresetsDropdown" class="ks-pivot-table-presets-dropdown">
-                    <a id="closePanelBtn"><span class="icon-arrow-to-top" style="color: #007BFF;"></span>Close Panel</a>
-                    <a id="resetPivotBtn"><span class="icon-clear" style="color: #dc3545;"></span>Reset</a>
-                    <a id="savePresetBtn"><span class="icon-tray-arrow-down" style="color: #3AA745;"></span>Save as Preset</a>
-                    <a id="loadPresetBtn"><span class="icon-tray-files" style="color: #1d7bff;"></span>Load Preset</a>
+                    <a id="closePanelBtn"><span class="icon-arrow-to-top" style="color: #007BFF;"></span>${Utils.translate('Close Panel')}</a>
+                    <a id="resetPivotBtn"><span class="icon-clear" style="color: #dc3545;"></span>${Utils.translate('Reset')}</a>
+                    <a id="savePresetBtn"><span class="icon-tray-arrow-down" style="color: #3AA745;"></span>${Utils.translate('Save as Preset')}</a>
+                    <a id="loadPresetBtn"><span class="icon-tray-files" style="color: #1d7bff;"></span>${Utils.translate('Load Preset')}</a>
                     <hr>
-                    <a><span class="icon-zero-square-outline" style="color: #80379b;"></span>Suppress Zero</a>
-                    <a class="suppressZeroBtn" data-id="${this.options.id}" data-type="nonEmptyColumns"><span class="icon-check" style="color: #1d7bff;"></span>From columns</a>
-                    <a class="suppressZeroBtn" data-id="${this.options.id}" data-type="nonEmptyRows"><span class="icon-check" style="color: #1d7bff;"></span>From rows</a>
+                    <a><span class="icon-zero-square-outline" style="color: #80379b;"></span>${Utils.translate('Suppress Zero')}</a>
+                    <a class="suppressZeroBtn" data-id="${this.options.id}" data-type="nonEmptyColumns"><span class="icon-check" style="color: #1d7bff;"></span>${Utils.translate('From columns')}</a>
+                    <a class="suppressZeroBtn" data-id="${this.options.id}" data-type="nonEmptyRows"><span class="icon-check" style="color: #1d7bff;"></span>${Utils.translate('From rows')}</a>
                     <hr>
-                    <a id="exportBtnInline" data-id="${this.options.id}" data-action="exportPivotTable"><span class="icon-doc-arrow-down" style="color: #3AA745;"></span>Export to Excel</a>
+                    <a id="exportBtnInline" data-id="${this.options.id}" data-action="exportPivotTable"><span class="icon-doc-arrow-down" style="color: #3AA745;"></span>${Utils.translate('Export to Excel')}</a>
                 </div>
             </div>
         </div>`;
         } else {
             const suppressLabels = {
-                all: 'All',
-                columns: 'Columns',
-                rows: 'Rows',
-                off: 'OFF'
+                all: Utils.translate('All'),
+                columns: Utils.translate('Columns'),
+                rows: Utils.translate('Rows'),
+                off: Utils.translate('OFF')
             };
             const currSuppress = suppressLabels[this.suppressZeroMode || 'off'];
             return `
 <div class="ks-pivot-table-control-row presets-row pivot-btn-row left-align">
-    <button id="resetPivotBtn" class="pivot-btn-outline"><span class="icon-arrow-undo"></span> Reset</button>
-    <button id="savePresetBtn" class="pivot-btn-outline"><span class="icon-tray-arrow-down"></span> Save as Preset</button>
-    <button id="loadPresetBtn" class="pivot-btn-outline"><span class="icon-tray-files"></span> Load Preset</button>
+    <button id="resetPivotBtn" class="pivot-btn-outline"><span class="icon-arrow-undo"></span> ${Utils.translate('Reset')}</button>
+    <button id="savePresetBtn" class="pivot-btn-outline"><span class="icon-tray-arrow-down"></span> ${Utils.translate('Save as Preset')}</button>
+    <button id="loadPresetBtn" class="pivot-btn-outline"><span class="icon-tray-files"></span> ${Utils.translate('Load Preset')}</button>
     <span class="pivot-btn-outline-group" style="position:relative;">
-      <span class="pivot-btn-outline-label">Supress Zero:</span>
+      <span class="pivot-btn-outline-label">${Utils.translate('Supress Zero:')}</span>
       <button id="suppressZeroDropdownBtn" class="pivot-btn-outline suppressZeroDropdownBtn" type="button">${currSuppress}</button>
       <div id="suppressZeroPopup" class="suppress-zero-popup" style="display:none;position:absolute;z-index:999;left:0;top:40px;"></div>
     </span>
-    <span class="pivot-btn-outline-label" style="margin-left:24px;">Excel:</span>
+    <span class="pivot-btn-outline-label" style="margin-left:24px;">${Utils.translate('Excel:')}</span>
     <button id="exportBtn" class="pivot-btn-outline"><span class="icon-doc-arrow-down"></span></button>
 </div>`;
         }
@@ -266,7 +267,7 @@ class PivotTableWidget extends Widget {
             h += '<div data-name="' + color.name + '" data-hex="' + color.hex + '" class="ks-pivot-tag-color-dropdown-chooser-item" style="background-color: #' + color.hex + ';"></div>';
         }
 
-        h += '</div></div></div><div class="ks-pivot-tag-button-holder"><a id="selectorTreeCancelBtn" class="ks-pivot-btn btn-blue-light"><span class="icon-x-circle"></span>Cancel</a><a id="selectorTreeSaveBtn" class="ks-pivot-btn btn-blue"><span style="color: #fff;" class="icon-check-on"></span>Save</a><a id="selectorTreeViewBtn" class="ks-pivot-btn btn-blue"><span style="color: #fff;" class="icon-glasses"></span>View</a></div></div><div class="ks-pivot-tag-add-holder">';
+        h += '</div></div></div><div class="ks-pivot-tag-button-holder"><a id="selectorTreeCancelBtn" class="ks-pivot-btn btn-blue-light"><span class="icon-x-circle"></span>' + Utils.translate('Cancel') + '</a><a id="selectorTreeSaveBtn" class="ks-pivot-btn btn-blue"><span style="color: #fff;" class="icon-check-on"></span>' + Utils.translate('Save') + '</a><a id="selectorTreeViewBtn" class="ks-pivot-btn btn-blue"><span style="color: #fff;" class="icon-glasses"></span>' + Utils.translate('View') + '</a></div></div><div class="ks-pivot-tag-add-holder">';
 
         h += this.renderNextSelectorTreeLevel(this.tree) + '</div></div>';
 
@@ -626,7 +627,7 @@ class PivotTableWidget extends Widget {
         const aliasAttrName = isElementCol ? this.getSelectedAliasAttributeName(cols.eq(0).data('value'), cols.eq(1).data('value'), cols.eq(2).data('value')) : false;
 
         let el, name, displayName, isSubsetSelected, defaultSubsetItem = '', h = '',
-            g = '<div data-type="' + types[i] + '" class="ks-pivot-tag-add-col ' + (isCheckableCol ? 'checkable-col' : '') + '"><div class="ks-pivot-add-tag-search-holder"><div class="ks-pivot-add-tag-search"><span class="icon-search"></span><input type="text" placeholder="Search..."></div></div><div class="ks-pivot-tag-add-col-content"><div class="ks-pivot-tag-add-item title-item">' + (isElementCol ? ('<span id="pivotElementsCheckbox"></span>') : '') + this.selectorTreeColNames[i] + (isElementCol ? '<span class="icon-aa"><div class="ks-pivot-table-presets-dropdown"></div></span>' : '') + '</div>';
+            g = '<div data-type="' + types[i] + '" class="ks-pivot-tag-add-col ' + (isCheckableCol ? 'checkable-col' : '') + '"><div class="ks-pivot-add-tag-search-holder"><div class="ks-pivot-add-tag-search"><span class="icon-search"></span><input type="text" placeholder="' + Utils.translate('Search...') + '"></div></div><div class="ks-pivot-tag-add-col-content"><div class="ks-pivot-tag-add-item title-item">' + (isElementCol ? ('<span id="pivotElementsCheckbox"></span>') : '') + this.selectorTreeColNames[i] + (isElementCol ? '<span class="icon-aa"><div class="ks-pivot-table-presets-dropdown"></div></span>' : '') + '</div>';
 
         if (isCheckableCol) {
             let check, del, c, chevron = isElementCol ? '' : '<span class="icon-chevron-right"></span>',
@@ -966,15 +967,15 @@ class PivotTableWidget extends Widget {
 
         this.popup = $(`
             <div class="ks-pivot ks-pivot-tag-add-popup">
-                <h3>Save as New Subset</h3>
-                <label>Subset Title</label>
+                <h3>${Utils.translate('Save as New Subset')}</h3>
+                <label>${Utils.translate('Subset Title')}</label>
                 <input type="text">
                 <div class="ks-pivot-popup-check-holder">
-                    <span class="icon-check off" style="color: #1d7bff;"></span>This Subset is Public
+                    <span class="icon-check off" style="color: #1d7bff;"></span>${Utils.translate('This Subset is Public')}
                 </div>
                 <div class="ks-pivot-tag-add-popup-button-holder">
-                    <a class="ks-pivot-btn btn-blue-light">Cancel</a>
-                    <a data-action="save" class="ks-pivot-btn btn-blue">Save</a>
+                    <a class="ks-pivot-btn btn-blue-light">${Utils.translate('Cancel')}</a>
+                    <a data-action="save" class="ks-pivot-btn btn-blue">${Utils.translate('Save')}</a>
                 </div>
             </div>
         `);
@@ -1099,7 +1100,7 @@ class PivotTableWidget extends Widget {
     }
 
     removeSubset(subset) {
-        this.popup = $('<div class="ks-pivot ks-pivot-tag-add-popup"><div style="text-align: center;margin: 15px;"><span class="icon-trash-fill" style="color: #DC3545;font-size: 30px;"></span></div><h2 style="text-align: center;">Delete Subset</h2><h3>Are you sure?<br>This action cannot be undone!</h3><div class="ks-pivot-tag-add-popup-button-holder"><a class="ks-pivot-btn btn-blue-light">Cancel</a><a data-action="yes" class="ks-pivot-btn btn-red-bg">Delete</a></div></div>');
+        this.popup = $('<div class="ks-pivot ks-pivot-tag-add-popup"><div style="text-align: center;margin: 15px;"><span class="icon-trash-fill" style="color: #DC3545;font-size: 30px;"></span></div><h2 style="text-align: center;">' + Utils.translate('Delete Subset') + '</h2><h3>' + Utils.translate('Are you sure?<br>This action cannot be undone!') + '</h3><div class="ks-pivot-tag-add-popup-button-holder"><a class="ks-pivot-btn btn-blue-light">' + Utils.translate('Cancel') + '</a><a data-action="yes" class="ks-pivot-btn btn-red-bg">' + Utils.translate('Delete') + '</a></div></div>');
 
         this.popup.on('click', 'a', e => {
             if ('yes' === $(e.currentTarget).data('action')) {
@@ -1216,7 +1217,7 @@ class PivotTableWidget extends Widget {
             list += '<a title="' + n.name + '" data-id="' + i + '" class="ellipsis"><span class="icon-check' + (i === id ? '' : ' off') + '"></span><span class="icon-' + ('Public' === n.type ? 'globe-lines' : 'person-outline') + '"></span>' + n.name + (n.isOwner ? '<span class="icon-trash"></span>' : '') + '</a>';
         }
 
-        this.popup = $('<div class="ks-pivot ks-pivot-tag-add-popup"><h3>Please select the Preset to load</h3><div class="ks-pivot-filterbox ks-pivot-table-presets-dropdown"><div class="ks-pivot-add-tag-search"><span class="icon-search"></span><input type="text" placeholder="Search..."></div><div class="ks-pivot-scrollable">' + list + '</div><hr><a data-load="1" class="ks-pivot-btn btn-blue-light">Load</a><a class="ks-pivot-btn btn-red">Cancel</a></div></div>');
+        this.popup = $('<div class="ks-pivot ks-pivot-tag-add-popup"><h3>' + Utils.translate('Please select the Preset to load') + '</h3><div class="ks-pivot-filterbox ks-pivot-table-presets-dropdown"><div class="ks-pivot-add-tag-search"><span class="icon-search"></span><input type="text" placeholder="' + Utils.translate('Search...') + '"></div><div class="ks-pivot-scrollable">' + list + '</div><hr><a data-load="1" class="ks-pivot-btn btn-blue-light">' + Utils.translate('Load') + '</a><a class="ks-pivot-btn btn-red">' + Utils.translate('Cancel') + '</a></div></div>');
 
         this.showPopup();
 
@@ -1290,7 +1291,7 @@ class PivotTableWidget extends Widget {
 
     deletePreset(a) {
         let v = this.presets[a.data('id')], d = {pID: v.id, pValue: '', pName: '', pType: ''},
-            p = $('<div style="width: 600px;" class="ks-pivot ks-pivot-tag-add-popup"><div style="text-align: center;margin: 15px;"><span class="icon-trash-fill" style="color: #DC3545;font-size: 30px;"></span></div><h2 style="text-align: center;">Delete Preset</h2><h3>Are you sure you want to delete the "' + a.attr('title') + '" ' + v.type + ' Preset?<br><br>This action cannot be undone!</h3><div class="ks-pivot-tag-add-popup-button-holder"><a class="ks-pivot-btn btn-blue-light">Cancel</a><a data-action="yes" class="ks-pivot-btn btn-red-bg">Delete</a></div></div>');
+            p = $('<div style="width: 600px;" class="ks-pivot ks-pivot-tag-add-popup"><div style="text-align: center;margin: 15px;"><span class="icon-trash-fill" style="color: #DC3545;font-size: 30px;"></span></div><h2 style="text-align: center;">' + Utils.translate('Delete Preset') + '</h2><h3>' + Utils.translate('Are you sure you want to delete the "') + a.attr('title') + '" ' + v.type + ' ' + Utils.translate('Preset?<br><br>This action cannot be undone!') + '</h3><div class="ks-pivot-tag-add-popup-button-holder"><a class="ks-pivot-btn btn-blue-light">' + Utils.translate('Cancel') + '</a><a data-action="yes" class="ks-pivot-btn btn-red-bg">' + Utils.translate('Delete') + '</a></div></div>');
 
         El.body.append(p);
 
@@ -1313,7 +1314,7 @@ class PivotTableWidget extends Widget {
     savePreset() {
         let id = this.presetId, d = this.presets[id] || {}, isPublic = 'Public' === d.type;
 
-        this.popup = $('<div class="ks-pivot ks-pivot-tag-add-popup"><h3>Please set the Preset name a visibility</h3><div class="ks-pivot-add-tag-search"><input value="' + (d.name || '') + '" type="text" placeholder="The Preset name..."></div><div class="ks-pivot-popup-check-holder"><span class="icon-check' + (isPublic ? '' : ' off') + '" style="color: #1d7bff;"></span>The Preset is Public</div><div class="ks-pivot-tag-add-popup-button-holder"><a class="ks-pivot-btn btn-blue-light">Cancel</a><a class="ks-pivot-btn btn-blue">Save</a></div></div>');
+        this.popup = $('<div class="ks-pivot ks-pivot-tag-add-popup"><h3>' + Utils.translate('Please set the Preset name a visibility') + '</h3><div class="ks-pivot-add-tag-search"><input value="' + (d.name || '') + '" type="text" placeholder="' + Utils.translate('The Preset name...') + '"></div><div class="ks-pivot-popup-check-holder"><span class="icon-check' + (isPublic ? '' : ' off') + '" style="color: #1d7bff;"></span>' + Utils.translate('The Preset is Public') + '</div><div class="ks-pivot-tag-add-popup-button-holder"><a class="ks-pivot-btn btn-blue-light">' + Utils.translate('Cancel') + '</a><a class="ks-pivot-btn btn-blue">' + Utils.translate('Save') + '</a></div></div>');
 
         let n = this.popup.find('input'), c = this.popup.find('.icon-check');
 
@@ -1335,7 +1336,7 @@ class PivotTableWidget extends Widget {
         let p = this.presets, i, j, k = null, f, d = [], t = isPublic ? 'Public' : 'Private';
 
         if (!presetName) {
-            app.popup.show('Please give a Preset name to save.', 300);
+            app.popup.show(Utils.translate('Please give a Preset name to save.'), 300);
             return;
         }
 
@@ -1353,7 +1354,7 @@ class PivotTableWidget extends Widget {
         }
 
         if (isPublic && f) {
-            app.popup.show('A Public Preset with the same name "' + presetName + '" already exists.<br>Please change the name or set the visibility to Private.', 550);
+            app.popup.show(Utils.translate('A Public Preset with the same name "') + presetName + Utils.translate('" already exists.<br>Please change the name or set the visibility to Private.'), 550);
             return;
         } else if (null === k) {
             k = p.length;
@@ -1426,10 +1427,10 @@ class PivotTableWidget extends Widget {
 
     showSuppressZeroPopup(btn) {
         const options = [
-            {mode: 'all', label: 'All'},
-            {mode: 'columns', label: 'Columns'},
-            {mode: 'rows', label: 'Rows'},
-            {mode: 'off', label: 'OFF'}
+            {mode: 'all', label: Utils.translate('All')},
+            {mode: 'columns', label: Utils.translate('Columns')},
+            {mode: 'rows', label: Utils.translate('Rows')},
+            {mode: 'off', label: Utils.translate('OFF')}
         ];
         const currMode = this.suppressZeroMode || 'off';
         let html = options.map(opt =>
@@ -1522,7 +1523,7 @@ class PivotTableWidget extends Widget {
             h += '<a data-name="' + n + '" data-alias="' + e + '" title="' + t + '" class="ellipsis"><span class="icon-check' + s + '"></span>' + t + '</a>';
         }
 
-        e = $('<div class="ks-pivot-filterbox ks-pivot-table-presets-dropdown"><div class="ks-pivot-add-tag-search"><span class="icon-search"></span><input type="text" placeholder="Search..."></div><div class="ks-pivot-scrollable">' + h + '</div><hr><a class="ks-pivot-btn btn-blue-light">Edit List</a><a class="ks-pivot-btn btn-red">Delete Filter</a></div>');
+        e = $('<div class="ks-pivot-filterbox ks-pivot-table-presets-dropdown"><div class="ks-pivot-add-tag-search"><span class="icon-search"></span><input type="text" placeholder="' + Utils.translate('Search...') + '"></div><div class="ks-pivot-scrollable">' + h + '</div><hr><a class="ks-pivot-btn btn-blue-light">' + Utils.translate('Edit List') + '</a><a class="ks-pivot-btn btn-red">' + Utils.translate('Delete Filter') + '</a></div>');
 
         e.on('click', false).on('click', '.btn-blue-light', () => this.openSelectorTreeFromCard(card)).on('click', '.btn-red', () => card.children('.icon-x-circle').click());
 

--- a/analogic/static/assets/js/widgets/segmented-bar.js
+++ b/analogic/static/assets/js/widgets/segmented-bar.js
@@ -1,4 +1,4 @@
-/* global app, Widget */
+/* global app, Widget, Utils */
 
 'use strict';
 class SegmentedBarWidget extends Widget {
@@ -30,7 +30,7 @@ class SegmentedBarWidget extends Widget {
 
             this.addSeparatorHtml(h, e);
 
-            h.push('<div class="ks-segmentedbar-block color-', i % 2 + 1, '" style="background: ', e.bgColor || 'inherit', '; width: ', w, '%;"><div style="color: ', e.color || 'inherit', ';" class="ks-segmentedbar-block-label">', e.label, '<\/div><\/div>');
+            h.push('<div class="ks-segmentedbar-block color-', i % 2 + 1, '" style="background: ', e.bgColor || 'inherit', '; width: ', w, '%;"><div style="color: ', e.color || 'inherit', ';" class="ks-segmentedbar-block-label">', e.label ? Utils.translate(e.label) : '', '<\/div><\/div>');
         }
 
         this.addSeparatorHtml(h, f);

--- a/analogic/static/assets/js/widgets/segmented-control-item.js
+++ b/analogic/static/assets/js/widgets/segmented-control-item.js
@@ -1,4 +1,4 @@
-/* global Widget */
+/* global Widget, Utils */
 
 'use strict';
 
@@ -14,7 +14,7 @@ class SegmentedControlItemWidget extends Widget {
             value: this.getRealValue('value', d, '')
         };
 
-        return `<a id="${o.id + '_' + d.id}" data-id="${d.id}" data-value="${v.value}" data-action="${v.action}" class="ks-segment ${v.selected ? ' ks-on' : ''} ks-segmented-${v.skin}"  style="${this.getGeneralStyles(d).join('')}"><div class="ks-segment-inner"><div class="ks-segment-icon"></div><div class="ks-segment-label">${v.label}</div></div></a>`;
+        return `<a id="${o.id + '_' + d.id}" data-id="${d.id}" data-value="${v.value}" data-action="${v.action}" class="ks-segment ${v.selected ? ' ks-on' : ''} ks-segmented-${v.skin}"  style="${this.getGeneralStyles(d).join('')}"><div class="ks-segment-inner"><div class="ks-segment-icon"></div><div class="ks-segment-label">${Utils.translate(v.label)}</div></div></a>`;
     }
 }
 ;

--- a/analogic/static/assets/js/widgets/segmented-control.js
+++ b/analogic/static/assets/js/widgets/segmented-control.js
@@ -1,4 +1,4 @@
-/* global app, Listeners, QB, Widget */
+/* global app, Listeners, QB, Widget, Utils */
 
 'use strict';
 
@@ -91,7 +91,7 @@ class SegmentedControlWidget extends Widget {
                 }
 
                 let visible = data && typeof data.visible !== 'undefined' ? data.visible : o.visible;
-                return `<section title="${o.title || ''}" ${visible === false ? 'style="display:none"' : 'style="display:contents;"'} id="${o.id}">${instance.getHtml(widgetHtmls, instance.processData(data), withState)}</section>`;
+                return `<section title="${o.title ? Utils.translate(o.title) : ''}" ${visible === false ? 'style="display:none"' : 'style="display:contents;"'} id="${o.id}">${instance.getHtml(widgetHtmls, instance.processData(data), withState)}</section>`;
             });
         });
     }

--- a/analogic/static/assets/js/widgets/slider.js
+++ b/analogic/static/assets/js/widgets/slider.js
@@ -78,8 +78,8 @@ class SliderWidget extends Widget {
                 </div>
             </div>
             <div class="ks-slider-touch-options-buttons">
-                <div class="ks-slider-touch-options-button ks-button-cancel">Cancel</div>
-                <div class="ks-slider-touch-options-button ks-button-update">OK</div>
+                <div class="ks-slider-touch-options-button ks-button-cancel">${Utils.translate('Cancel')}</div>
+                <div class="ks-slider-touch-options-button ks-button-update">${Utils.translate('OK')}</div>
             </div>
         </div>
     </div>
@@ -110,22 +110,22 @@ class SliderWidget extends Widget {
 
     <div class="ks-slider-options">
         <div class="ks-slider-options-controls">
-            <div class="ks-slider-options-label">Current Value</div>
+            <div class="ks-slider-options-label">${Utils.translate('Current Value')}</div>
             <div class="ks-slider-options-input">
                 <input type="text" value="">
                 <div class="ks-slider-options-input-label ks-label-min">
-                    <div class="ks-slider-options-input-label-name">Min</div>
+                    <div class="ks-slider-options-input-label-name">${Utils.translate('Min')}</div>
                     <div class="ks-slider-options-input-label-value">${v.minRange}</div>
                 </div>
                 <div class="ks-slider-options-input-label ks-label-max">
-                    <div class="ks-slider-options-input-label-name">Max</div>
+                    <div class="ks-slider-options-input-label-name">${Utils.translate('Max')}</div>
                     <div class="ks-slider-options-input-label-value">${v.maxRange}</div>
                 </div>
             </div>
         </div>
         <div class="ks-slider-options-buttons">
-            <div class="ks-slider-options-button ks-button-cancel">Cancel</div>
-            <div class="ks-slider-options-button ks-button-update">Update</div>
+            <div class="ks-slider-options-button ks-button-cancel">${Utils.translate('Cancel')}</div>
+            <div class="ks-slider-options-button ks-button-update">${Utils.translate('Update')}</div>
         </div>
     </div>
     ${this.createLegendHmtml()}
@@ -403,7 +403,7 @@ class SliderWidget extends Widget {
         }
 
         for (d of v.legend) {
-            h += '<div data-id="' + (++i) + '" style="background-color:' + d.color + ';" class="ks-legend-item"><div class="ks-legend-item-inner"><div style="color: #000;" class="ks-legend-icon"></div><div style="color: #000;" class="ks-legend-label">' + d.name + '</div></div></div>';
+            h += '<div data-id="' + (++i) + '" style="background-color:' + d.color + ';" class="ks-legend-item"><div class="ks-legend-item-inner"><div style="color: #000;" class="ks-legend-icon"></div><div style="color: #000;" class="ks-legend-label">' + (d.name ? Utils.translate(d.name) : '') + '</div></div></div>';
         }
 
         h += '</div></div>';

--- a/analogic/static/assets/js/widgets/text.js
+++ b/analogic/static/assets/js/widgets/text.js
@@ -49,8 +49,8 @@ class TextWidget extends Widget {
 <div class="ks-text ${mainDivClass.join(' ')} ks-text-${v.skin}" style="${mainDivStyle.join('')}">
     <div class="ks-text-inner" style="${innerStyles.join('')}" data-id="${o.id}" data-action="text_click" data-ordinal="${v.ordinal}">
         <div class="ks-text-icon" data-id="${o.id}" data-action="${v.iconCustomEventName ? v.iconCustomEventName : 'perform'}" data-ordinal="${v.ordinal}"><span style="${iconStyles.join('')}" class="${v.icon}"></span></div>
-        <div class="ks-text-title" data-performable="${v.performable ? '1' : '0'}" data-editable="${v.editable ? '1' : '0'}" title="${v.title && !v.tooltip ? Utils.htmlEncode(Utils.stripHtml(v.title)) : ''}" data-ordinal="${v.ordinal}" style="${titleStyles.join('')}">${v.title !== false ? v.title : ''}</div>
-        <div class="ks-text-body" style="${bodyStyles.join('')}">${v.body !== false ? v.body : ''}</div>
+        <div class="ks-text-title" data-performable="${v.performable ? '1' : '0'}" data-editable="${v.editable ? '1' : '0'}" title="${v.title && !v.tooltip ? Utils.htmlEncode(Utils.stripHtml(Utils.translate(v.title))) : ''}" data-ordinal="${v.ordinal}" style="${titleStyles.join('')}">${v.title !== false ? Utils.translate(v.title) : ''}</div>
+        <div class="ks-text-body" style="${bodyStyles.join('')}">${v.body !== false ? Utils.translate(v.body) : ''}</div>
     </div>
 </div>`;
     }
@@ -118,8 +118,8 @@ class TextWidget extends Widget {
         Widget.setOrRemoveStyle(inner, 'height', v.innerHeight ? Widget.getPercentOrPixel(v.innerHeight) : false);
 
         //title
-        title.html(v.title !== false ? v.title : '');
-        title.attr('title', v.title ? Utils.htmlEncode(Utils.stripHtml(v.title)) : '');
+        title.html(v.title !== false ? Utils.translate(v.title) : '');
+        title.attr('title', v.title ? Utils.htmlEncode(Utils.stripHtml(Utils.translate(v.title))) : '');
         if (v.title !== false) {
             mainDiv.addClass('has-title');
         }
@@ -127,7 +127,7 @@ class TextWidget extends Widget {
         Widget.setOrRemoveStyle(title, 'cursor', v.titleCursor);
 
         //body
-        body.html(v.body !== false ? v.body : '');
+        body.html(v.body !== false ? Utils.translate(v.body) : '');
         if (v.body !== false) {
             mainDiv.addClass('has-body');
         }

--- a/analogic/static/assets/js/widgets/textarea.js
+++ b/analogic/static/assets/js/widgets/textarea.js
@@ -40,14 +40,14 @@ class TextAreaWidget extends Widget {
 <div class="ks-textarea ${mainDivClass.join(' ')} ks-textarea-${v.skin}"  style="${mainDivStyle.join('')}">
     <div class="ks-textarea-inner">
         <div class="ks-textarea-title" style="${titleStyles.join('')}">
-            <span class="ks-textarea-title-primary">${v.title ? v.title : ''}</span>
+            <span class="ks-textarea-title-primary">${v.title ? Utils.translate(v.title) : ''}</span>
             <span class="ks-textarea-title-secondary"></span>
         </div>
         <div class="ks-textarea-field">
             <div class="ks-textarea-field-inner">
                 <div class="ks-textarea-icon">${v.icon !== false ? `<img style="${iconStyles.join('')}" src="${app.applicationAssetsUrl}/skin/images/${v.icon}">` : ''}</div>
                 <div class="ks-textarea-divider"></div>
-                <textarea ${v.editable ? '' : 'disabled'} ${v.placeholder !== false ? `placeholder="${v.placeholder}"` : ''} style="${textStyles.join('')}" data-action="save" data-ordinal="${d.ordinal}" data-id="${o.id}" class="ks-textarea-input" >${d.value || ''}</textarea>
+                <textarea ${v.editable ? '' : 'disabled'} ${v.placeholder !== false ? `placeholder="${Utils.translate(v.placeholder)}"` : ''} style="${textStyles.join('')}" data-action="save" data-ordinal="${d.ordinal}" data-id="${o.id}" class="ks-textarea-input" >${d.value || ''}</textarea>
             </div>
         </div>
     </div>
@@ -101,6 +101,7 @@ class TextAreaWidget extends Widget {
         this.value = Utils.escapeText(d.value);
 
         textarea.val(d.value);
+        textarea.attr('placeholder', p.placeholder === false ? '' : Utils.translate(p.placeholder));
     }
 
     reset() {

--- a/analogic/static/assets/js/widgets/textbox.js
+++ b/analogic/static/assets/js/widgets/textbox.js
@@ -44,14 +44,14 @@ class TextBoxWidget extends Widget {
 <div class="ks-textbox ${mainDivClass.join(' ')} ks-textbox-${v.skin}"  style="${mainDivStyle.join('')}">
     <div class="ks-textbox-inner">
         <div class="ks-textbox-title" style="${titleStyles.join('')}">
-            <span class="ks-textbox-title-primary">${v.title ? v.title : ''}</span>
+            <span class="ks-textbox-title-primary">${v.title ? Utils.translate(v.title) : ''}</span>
             <span class="ks-textbox-title-secondary"></span>
         </div>
         <div class="ks-textbox-field">
             <div class="ks-textbox-field-inner ${v.editable === false ? 'readonly' : ''}">
                 <div class="ks-textbox-icon" style="${iconStyles.join('')}">${v.icon !== false ? `<img src="${app.applicationAssetsUrl}/skin/images/${v.icon}">` : ''}</div>
                 <div class="ks-textbox-divider"></div>
-                <input ${v.editable === false ? 'readonly' : ''} style="${textStyles.join('')}" data-action="writeEnd" data-id="${o.id}"  type="${v.textBoxType}" value="${Utils.htmlEncode(d.value)}" class="ks-textbox-input" placeholder="${v.defaultText ? v.defaultText : ''}">
+                <input ${v.editable === false ? 'readonly' : ''} style="${textStyles.join('')}" data-action="writeEnd" data-id="${o.id}"  type="${v.textBoxType}" value="${Utils.htmlEncode(d.value)}" class="ks-textbox-input" placeholder="${v.defaultText ? Utils.translate(v.defaultText) : ''}">
             </div>
         </div>
     </div>
@@ -72,7 +72,7 @@ class TextBoxWidget extends Widget {
 
         this.addDynamicData(data, p);
 
-        input.attr('placeholder', p.defaultText === false ? '' : p.defaultText);
+        input.attr('placeholder', p.defaultText === false ? '' : Utils.translate(p.defaultText));
         input.attr('value', Utils.htmlEncode(data.value));
         input.val(data.value);
 

--- a/analogic/static/assets/js/widgets/toggle.js
+++ b/analogic/static/assets/js/widgets/toggle.js
@@ -1,4 +1,4 @@
-/* global app, Widget, Widgets */
+/* global app, Widget, Widgets, Utils */
 
 'use strict';
 
@@ -31,7 +31,7 @@ class ToggleWidget extends Widget {
         iconStyles = iconStyles.join('');
 
         if (v.groupId && b) {
-            Widgets[v.groupId] = {ordinal: d.ordinal, value: v.titleOn};
+            Widgets[v.groupId] = {ordinal: d.ordinal, value: Utils.translate(v.titleOn)};
         }
 
         return `
@@ -39,8 +39,8 @@ class ToggleWidget extends Widget {
     <div class="ks-toggle-inner ${v.editable === false ? 'readonly' : ''}">
         <div style="${iconStyles}" class="ks-toggle-icon ks-toggle-icon-on">${v.icon ? `<span class="${v.icon}"></span>` : ''}</div>
         <div style="${iconStyles}" class="ks-toggle-icon ks-toggle-icon-off">${v.iconOff ? `<span class="${v.iconOff}"></span>` : ''}</div>
-        <div style="${titleStyles}" class="ks-toggle-label ks-toggle-label-on">${v.titleOn}</div>
-        <div style="${titleStyles}" class="ks-toggle-label ks-toggle-label-off">${v.titleOff}</div>
+        <div style="${titleStyles}" class="ks-toggle-label ks-toggle-label-on">${Utils.translate(v.titleOn)}</div>
+        <div style="${titleStyles}" class="ks-toggle-label ks-toggle-label-off">${Utils.translate(v.titleOff)}</div>
     </div>
 </div>`;
     }
@@ -60,12 +60,12 @@ class ToggleWidget extends Widget {
             main.removeClass('ks-on');
         }
 
-        titleOn.html(p.titleOn);
+        titleOn.html(Utils.translate(p.titleOn));
         Widget.setOrRemoveStyle(titleOn, 'color', p.titleFontColor);
 
         Widget.setOrRemoveStyle(iconOn, 'color', p.iconFontColor);
 
-        titleOff.html(p.titleOff);
+        titleOff.html(Utils.translate(p.titleOff));
         Widget.setOrRemoveStyle(titleOff, 'color', p.titleFontColor);
 
         Widget.setOrRemoveStyle(iconOff, 'color', p.iconFontColor);

--- a/analogic/static/assets/js/widgets/vertical-line-box.js
+++ b/analogic/static/assets/js/widgets/vertical-line-box.js
@@ -1,4 +1,4 @@
-/* global app, Widget */
+/* global app, Widget, Utils */
 
 'use strict';
 class VerticalLineBoxWidget extends Widget {
@@ -29,7 +29,7 @@ class VerticalLineBoxWidget extends Widget {
 
             titleClass = '';
 
-            h.push('<div class="ks-vertical-label', (e.labelVisible ? '' : ' hidden'), '" style="left: ', left, '%; color: ', (e.labelColor || 'inherit'), ';">', e.label || '', '<\/div>');
+            h.push('<div class="ks-vertical-label', (e.labelVisible ? '' : ' hidden'), '" style="left: ', left, '%; color: ', (e.labelColor || 'inherit'), ';">', e.label ? Utils.translate(e.label) : '', '<\/div>');
 
             if (e.labelVisible) {
                 if (!heightClasses.includes('ks-vertical-line-has-label')) {
@@ -38,7 +38,7 @@ class VerticalLineBoxWidget extends Widget {
             }
 
             if (e.titleVisible) {
-                h.push('<div class="ks-vertical-title" style="color: ', (e.titleColor || 'inherit'), '; background: ', (e.titleBgColor || 'inherit'), '; left: ', left, '%;">', e.title || '', '<\/div>');
+                h.push('<div class="ks-vertical-title" style="color: ', (e.titleColor || 'inherit'), '; background: ', (e.titleBgColor || 'inherit'), '; left: ', left, '%;">', e.title ? Utils.translate(e.title) : '', '<\/div>');
 
                 titleClass = 'ks-vertical-line-has-title';
 


### PR DESCRIPTION
## Summary
- expose translations through new `Utils.translate`
- translate labels, placeholders, and titles across common widgets
- add translation to dropbox, date picker, horizontal table, and pivot table
- localize image, upload, segmented, slider, and vertical line widgets

## Testing
- `pytest analogic/tests`

------
https://chatgpt.com/codex/tasks/task_e_68a84805f0cc832b864172bce3bd6099