### PR TITLE
Regenerate translations on authentication cache clearing

### DIFF
--- a/analogic/authentication_provider.py
+++ b/analogic/authentication_provider.py
@@ -683,7 +683,14 @@ class AuthenticationProvider(ABC):
         return 'ok'
 
     def clear_cache(self):
-        return self.get_setting().clear_cache()
+        result = self.get_setting().clear_cache()
+        try:
+            provider = self.create_translation_provider()
+            if provider is not None:
+                provider.generate_translations()
+        except Exception as e:
+            self.getLogger().error(f"Error generating translations: {e}", exc_info=True)
+        return result
 
     def is_in_maintenance_mode(self):
         return self.is_in_maintenance

--- a/analogic/multi_authentication_provider.py
+++ b/analogic/multi_authentication_provider.py
@@ -157,7 +157,7 @@ class MultiAuthenticationProvider(AuthenticationProvider):
     def clear_cache(self):
         for name, registered_auth_prov in self.authentication_providers.items():
             registered_auth_prov.clear_cache()
-        self.get_setting().clear_cache()
+        return super().clear_cache()
 
     def initialize(self):
         for name, registered_auth_prov in self.authentication_providers.items():


### PR DESCRIPTION
## Summary
- Regenerate translations when clearing authentication provider cache
- Ensure multi authentication provider clears cache via base implementation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac60b1ace0832bbc5f216703be9b20