### PR TITLE
Add GridTableLight widget with paging and export features

### DIFF
--- a/analogic/static/assets/js/widgets/grid-table-light.js
+++ b/analogic/static/assets/js/widgets/grid-table-light.js
@@ -1,0 +1,123 @@
+/* global Widget, GridTableExport, Api, Repository, Widgets */
+
+'use strict';
+
+class GridTableLightWidget extends Widget {
+
+    getParameters(data) {
+        return {
+            pageSize: this.getRealValue('pageSize', data, 25),
+            freezeHeader: this.getRealValue('freezeHeader', data, true),
+            freezeFirstColumns: this.getRealValue('freezeFirstColumns', data, 0),
+            enableExport: this.getRealValue('enableExport', data, false)
+        };
+    }
+
+    getHtml(widgets, d) {
+        const params = this.getParameters(d || {});
+        const rows = Array.isArray(d) ? d : (d && d.content ? d.content : []);
+        this.cellData = rows;
+
+        const pageSize = params.pageSize > 0 ? params.pageSize : 0;
+        const page = this.state.page || 1;
+        const totalRows = rows.length;
+        const totalPages = pageSize > 0 ? Math.max(1, Math.ceil(totalRows / pageSize)) : 1;
+        let displayRows = rows;
+        if (pageSize > 0) {
+            const start = (page - 1) * pageSize;
+            displayRows = rows.slice(start, start + pageSize);
+        }
+
+        const headers = (d && d.headers) ? d.headers : (displayRows[0] ? displayRows[0].map((_, i) => 'Col ' + (i + 1)) : []);
+        const headerHtml = headers.map((h, idx) => {
+            let styles = [];
+            if (params.freezeHeader) {
+                styles.push('position:sticky;top:0;z-index:2;');
+            }
+            if (params.freezeFirstColumns > idx) {
+                styles.push('left:' + (idx * 100) + 'px;z-index:3;');
+            }
+            return `<th style="${styles.join('')}">${h}</th>`;
+        }).join('');
+
+        const bodyHtml = displayRows.map(row => {
+            return '<tr>' + row.map((cell, idx) => {
+                const text = (cell && cell.title !== undefined) ? cell.title : (cell !== undefined ? cell : '');
+                let styles = [];
+                if (params.freezeFirstColumns > idx) {
+                    styles.push('position:sticky;left:' + (idx * 100) + 'px;z-index:2;');
+                }
+                return `<td style="${styles.join('')}">${text}</td>`;
+            }).join('') + '</tr>';
+        }).join('');
+
+        let pagerHtml = '';
+        if (pageSize > 0 && totalRows > pageSize) {
+            pagerHtml = `<div class="ks-grid-table-light-pager">
+                <button class="first">&lt;&lt;</button>
+                <button class="prev">&lt;</button>
+                <span class="info">${page} / ${totalPages}</span>
+                <button class="next">&gt;</button>
+                <button class="last">&gt;&gt;</button>
+            </div>`;
+        }
+
+        let exportHtml = '';
+        if (params.enableExport) {
+            exportHtml = `<div class="ks-grid-table-light-export" title="Export">⤓</div>`;
+        }
+
+        return `<div class="ks-grid-table ks-grid-table-light">${exportHtml}<table>${headers.length ? `<thead><tr>${headerHtml}</tr></thead>` : ''}<tbody>${bodyHtml}</tbody></table>${pagerHtml}</div>`;
+    }
+
+    initEvents() {
+        const holder = this.getHolder(this.id);
+        const widget = this;
+        const pager = holder.find('.ks-grid-table-light-pager');
+        pager.find('button.first').on('click', () => widget.changePage(1));
+        pager.find('button.prev').on('click', () => widget.changePage((widget.state.page || 1) - 1));
+        pager.find('button.next').on('click', () => widget.changePage((widget.state.page || 1) + 1));
+        pager.find('button.last').on('click', () => {
+            const params = widget.getParameters({});
+            const total = Math.max(1, Math.ceil(widget.cellData.length / params.pageSize));
+            widget.changePage(total);
+        });
+        holder.find('.ks-grid-table-light-export').on('click', () => {
+            if (typeof GridTableExport !== 'undefined') {
+                GridTableExport.triggerExcelExport(widget.id);
+            }
+        });
+    }
+
+    changePage(page) {
+        const params = this.getParameters({});
+        if (params.pageSize <= 0) {
+            return;
+        }
+        const totalPages = Math.max(1, Math.ceil(this.cellData.length / params.pageSize));
+        page = Math.max(1, Math.min(totalPages, page));
+        this.state.page = page;
+        if (Repository[this.id] && Repository[this.id].url) {
+            const repo = Repository[this.id];
+            const baseFn = repo.originalUrl || repo.url;
+            repo.originalUrl = baseFn;
+            repo.url = (db) => {
+                const baseUrl = typeof baseFn === 'function' ? baseFn(db) : baseFn;
+                const skip = (page - 1) * params.pageSize;
+                const sep = baseUrl.indexOf('?') === -1 ? '?' : '&';
+                return `${baseUrl}${sep}$top=${params.pageSize}&$skip=${skip}`;
+            };
+            Api.forceRefresh(this.id);
+        } else {
+            this.renderPage();
+        }
+    }
+
+    renderPage() {
+        this.getHolder(this.id).html(this.getHtml([], {content: this.cellData}));
+        this.initEvents();
+    }
+}
+
+Widgets['GridTableLightWidget'] = GridTableLightWidget;
+

--- a/analogic/static/assets/skin/css/ks-grid-table-light-style.css
+++ b/analogic/static/assets/skin/css/ks-grid-table-light-style.css
@@ -1,0 +1,1 @@
+/* project specific overrides */

--- a/analogic/static/assets/skin/css/ks-grid-table-light.css
+++ b/analogic/static/assets/skin/css/ks-grid-table-light.css
@@ -1,0 +1,5 @@
+.ks-grid-table-light { position: relative; }
+.ks-grid-table-light table { width: 100%; border-collapse: collapse; }
+.ks-grid-table-light th, .ks-grid-table-light td { border: 1px solid #ccc; padding: 4px; background: #fff; }
+.ks-grid-table-light-pager { position: absolute; right: 4px; bottom: 4px; display: flex; gap: 4px; background: rgba(255,255,255,0.9); padding: 4px; }
+.ks-grid-table-light-export { position: absolute; top: 4px; right: 4px; cursor: pointer; }

--- a/analogic/templates/css.html
+++ b/analogic/templates/css.html
@@ -28,6 +28,9 @@
 <link href="{{url_for('static', filename='assets/skin/css/ks-grid-table-cell.css')}}?v={{cnf.version}}" rel="stylesheet" type="text/css">
 <link href="{{url_for(cnf.blueprint_static, filename='assets/skin/css/ks-grid-table-cell-style.css')}}?v={{cnf.version}}" rel="stylesheet" type="text/css">
 
+<link href="{{url_for('static', filename='assets/skin/css/ks-grid-table-light.css')}}?v={{cnf.version}}" rel="stylesheet" type="text/css">
+<link href="{{url_for(cnf.blueprint_static, filename='assets/skin/css/ks-grid-table-light-style.css')}}?v={{cnf.version}}" rel="stylesheet" type="text/css">
+
 <link href="{{url_for('static', filename='assets/skin/css/ks-dropbox.css')}}?v={{cnf.version}}" rel="stylesheet" type="text/css">
 <link href="{{url_for(cnf.blueprint_static, filename='assets/skin/css/ks-dropbox-style.css')}}?v={{cnf.version}}" rel="stylesheet" type="text/css">
 

--- a/analogic/templates/javascripts.html
+++ b/analogic/templates/javascripts.html
@@ -77,6 +77,7 @@
 <script src="{{ url_for('static', filename='assets/js/widgets/grid-table/grid-table-cell.js') }}?v={{ cnf.version }}"></script>
 <script src="{{ url_for('static', filename='assets/js/widgets/grid-table/grid-table-header-row.js') }}?v={{ cnf.version }}"></script>
 <script src="{{ url_for('static', filename='assets/js/widgets/grid-table/grid-table-header-cell.js') }}?v={{ cnf.version }}"></script>
+<script src="{{ url_for('static', filename='assets/js/widgets/grid-table-light.js') }}?v={{ cnf.version }}"></script>
 <script src="{{ url_for('static', filename='assets/js/widgets/button.js') }}?v={{ cnf.version }}"></script>
 <script src="{{ url_for('static', filename='assets/js/widgets/text.js') }}?v={{ cnf.version }}"></script>
 <script src="{{ url_for('static', filename='assets/js/widgets/textbox.js') }}?v={{ cnf.version }}"></script>

--- a/docs/source/gridtablelight_widget.rst
+++ b/docs/source/gridtablelight_widget.rst
@@ -1,0 +1,27 @@
+GridTableLightWidget
+====================
+
+A lightweight table widget intended for fast rendering and minimal configuration. The widget renders its own cell content instead of embedding individual widgets in every cell.
+
+Parameters
+----------
+
+- ``pageSize``: number, default ``25``. Maximum number of rows shown on a page. Use ``0`` to disable paging.
+- ``freezeHeader``: boolean, default ``true``. Keeps the table header visible during vertical scrolling.
+- ``freezeFirstColumns``: number, default ``0``. Count of leftmost columns that remain fixed during horizontal scrolling.
+- ``enableExport``: boolean, default ``false``. Shows an export icon that creates an Excel file of the full data set.
+
+Example
+-------
+
+::
+
+    {
+        id: 'sampleGridLight',
+        type: GridTableLightWidget,
+        pageSize: 50,
+        freezeHeader: true,
+        freezeFirstColumns: 1,
+        enableExport: true
+    }
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,6 +19,7 @@ Contents
 
    usage
    widgets
+   gridtablelight_widget
    repository
    eventmap
    createapp


### PR DESCRIPTION
## Summary
- implement lightweight `GridTableLightWidget` with paging, header/column freezing and Excel export
- add accompanying styles and load assets
- document widget parameters and usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b419ddbaf8832bb53a2449c14b595a