### PR TITLE
Add bandiTest alert option to GridTableLight widget

### DIFF
--- a/analogic/static/assets/js/widgets/grid-table-light.js
+++ b/analogic/static/assets/js/widgets/grid-table-light.js
@@ -9,12 +9,17 @@ class GridTableLightWidget extends Widget {
             pageSize: this.getRealValue('pageSize', data, 25),
             freezeHeader: this.getRealValue('freezeHeader', data, true),
             freezeFirstColumns: this.getRealValue('freezeFirstColumns', data, 0),
-            enableExport: this.getRealValue('enableExport', data, false)
+            enableExport: this.getRealValue('enableExport', data, false),
+            bandiTest: this.getRealValue('bandiTest', data, false)
         };
     }
 
     getHtml(widgets, d) {
         const params = this.getParameters(d || {});
+        if (params.bandiTest && !this.state.bandiTestAlertShown) {
+            alert('bandi teszt');
+            this.state.bandiTestAlertShown = true;
+        }
         const rows = Array.isArray(d) ? d : (d && d.content ? d.content : []);
         this.cellData = rows;
 

--- a/docs/source/gridtablelight_widget.rst
+++ b/docs/source/gridtablelight_widget.rst
@@ -10,6 +10,7 @@ Parameters
 - ``freezeHeader``: boolean, default ``true``. Keeps the table header visible during vertical scrolling.
 - ``freezeFirstColumns``: number, default ``0``. Count of leftmost columns that remain fixed during horizontal scrolling.
 - ``enableExport``: boolean, default ``false``. Shows an export icon that creates an Excel file of the full data set.
+- ``bandiTest``: boolean, default ``false``. When ``true``, displays an alert message "bandi teszt".
 
 Example
 -------
@@ -22,6 +23,7 @@ Example
         pageSize: 50,
         freezeHeader: true,
         freezeFirstColumns: 1,
-        enableExport: true
+        enableExport: true,
+        bandiTest: true
     }
 


### PR DESCRIPTION
## Summary
- add new `bandiTest` parameter to GridTableLightWidget
- document bandiTest option and usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bae33351048330bb8b154c2a2a9e75