### PR TITLE
fix: class loader prepends namespace with app name if necessary

### DIFF
--- a/analogic/loader.py
+++ b/analogic/loader.py
@@ -10,5 +10,9 @@ class ClassLoader:
         return getattr(sys.modules[n], s)
 
     def call(self, description, request, tm1_service, setting, authentication_provider, **kwargs):
-        my_object = self.str_to_class(description['namespace'], description['class'])
+        if setting.instance in description['namespace'].split('.'):
+            namespace = description['namespace']
+        else:
+            namespace = setting.instance + '.' + description['namespace']
+        my_object = self.str_to_class(namespace, description['class'])
         return getattr(my_object, description['method'])(self=my_object, request=request, tm1_service=tm1_service, setting=setting, authentication_provider=authentication_provider, **kwargs)


### PR DESCRIPTION
Updated the ClassLoader class's call() method to automatically assign the appropriate app to the namespace of the method to be called (if not already provided). Before getting the desired class from sys.modules, the call method now makes a check to see whether the received description object's namespace property contains the app name given in the setting object. If not, it prepends with setting.instance, else it keeps it as it is. This way, current custom_objects.json files do not have to be rewritten in already existing apps, but new apps' custom objects can be configured without the need to manually add or rewrite the app name in the namespace properties.