### PR TITLE
Capture MDX ordinals in GridTableLight data

### DIFF
--- a/analogic/static/assets/js/framework/utils.js
+++ b/analogic/static/assets/js/framework/utils.js
@@ -787,6 +787,169 @@ const Utils = {
 
         return floatingElement.css(pos).prependTo($('body'));
     },
+    transformMdxResponseToGridTableLight(response, options = {}) {
+        const emptyResult = {columns: [], content: []};
+
+        try {
+            if (!response || !Array.isArray(response.Cells)) {
+                console.error('Utils.transformMdxResponseToGridTableLight: invalid MDX response format.');
+                return emptyResult;
+            }
+
+            const cells = response.Cells;
+            if (!cells.length) {
+                console.error('Utils.transformMdxResponseToGridTableLight: MDX response does not contain any cells.');
+                return emptyResult;
+            }
+
+            let columnIndex = null;
+            for (let idx = 1; idx < cells.length; idx++) {
+                const previousMembers = Array.isArray(cells[idx - 1].Members) ? cells[idx - 1].Members : [];
+                const currentMembers = Array.isArray(cells[idx].Members) ? cells[idx].Members : [];
+                const length = Math.max(previousMembers.length, currentMembers.length);
+                const differences = [];
+
+                for (let memberIndex = 0; memberIndex < length; memberIndex++) {
+                    const previousName = previousMembers[memberIndex] ? previousMembers[memberIndex].Name : undefined;
+                    const currentName = currentMembers[memberIndex] ? currentMembers[memberIndex].Name : undefined;
+                    if (previousName !== currentName) {
+                        differences.push(memberIndex);
+                    }
+                }
+
+                if (1 === differences.length) {
+                    columnIndex = differences[0];
+                    break;
+                }
+            }
+
+            const firstMembers = Array.isArray(cells[0].Members) ? cells[0].Members : [];
+            if (null === columnIndex) {
+                if (firstMembers.length) {
+                    columnIndex = Math.min(firstMembers.length - 1, Math.max(firstMembers.length - 2, 0));
+                    console.warn('Utils.transformMdxResponseToGridTableLight: falling back to inferred column index', columnIndex);
+                } else {
+                    console.error('Utils.transformMdxResponseToGridTableLight: unable to determine column index.');
+                    return emptyResult;
+                }
+            }
+
+            const getRowKey = members => members
+                .map((member, idx) => idx === columnIndex ? '__COLUMN__' : (member && member.Name) || '')
+                .join('|');
+
+            const rowOrder = [];
+            const rowDataByKey = {};
+            const columnOrder = [];
+
+            for (let cellIndex = 0; cellIndex < cells.length; cellIndex++) {
+                const cell = cells[cellIndex] || {};
+                const members = Array.isArray(cell.Members) ? cell.Members : [];
+                const rowKey = getRowKey(members);
+
+                if (!rowDataByKey[rowKey]) {
+                    rowOrder.push(rowKey);
+                    const labelParts = members
+                        .filter((member, idx) => idx !== columnIndex && idx < members.length - 1 && member && member.Name)
+                        .map(member => member.Name);
+                    const label = labelParts.length ? labelParts[labelParts.length - 1] : `Row ${rowOrder.length}`;
+                    rowDataByKey[rowKey] = {
+                        label: label,
+                        description: labelParts.join(' / '),
+                        values: {},
+                        cellMeta: {},
+                        rowOrdinal: null
+                    };
+                }
+
+                const columnMember = members[columnIndex];
+                const columnName = columnMember && columnMember.Name ? columnMember.Name : `Column ${columnOrder.length + 1}`;
+                if (!columnOrder.includes(columnName)) {
+                    columnOrder.push(columnName);
+                }
+
+                const formattedValue = Object.prototype.hasOwnProperty.call(cell, 'FormattedValue') ? cell.FormattedValue : '';
+                rowDataByKey[rowKey].values[columnName] = formattedValue;
+
+                if (Object.prototype.hasOwnProperty.call(cell, 'Ordinal')) {
+                    const ordinal = cell.Ordinal;
+                    if (null === rowDataByKey[rowKey].rowOrdinal) {
+                        rowDataByKey[rowKey].rowOrdinal = ordinal;
+                    }
+                    rowDataByKey[rowKey].cellMeta[columnName] = {ordinal: ordinal};
+                }
+            }
+
+            console.log('Utils.transformMdxResponseToGridTableLight: detected column count', columnOrder.length);
+
+            const rowTitle = options.rowTitle || 'Item';
+            const columns = [
+                {
+                    key: 'rowLabel',
+                    title: rowTitle,
+                    alignment: 'center-left'
+                }
+            ];
+
+            for (let columnIdx = 0; columnIdx < columnOrder.length; columnIdx++) {
+                const name = columnOrder[columnIdx] || `Column ${columnIdx + 1}`;
+                columns.push({
+                    key: `col${columnIdx + 1}`,
+                    title: name,
+                    alignment: 'center-right'
+                });
+            }
+
+            const content = rowOrder.map((rowKey, index) => {
+                const rowData = rowDataByKey[rowKey];
+                const cellsForRow = [];
+
+                const rowLabelCell = {
+                    type: 'text',
+                    rawValue: rowData.label,
+                    displayValue: rowData.label,
+                    tooltip: rowData.description || rowData.label,
+                    alignment: 'center-left'
+                };
+                if (rowData.rowOrdinal !== null && typeof rowData.rowOrdinal !== 'undefined') {
+                    rowLabelCell.data = {ordinal: rowData.rowOrdinal};
+                }
+                cellsForRow.push(rowLabelCell);
+
+                for (let columnIdx = 0; columnIdx < columnOrder.length; columnIdx++) {
+                    const name = columnOrder[columnIdx];
+                    const value = Object.prototype.hasOwnProperty.call(rowData.values, name) ? rowData.values[name] : '';
+                    const meta = rowData.cellMeta && Object.prototype.hasOwnProperty.call(rowData.cellMeta, name)
+                        ? rowData.cellMeta[name]
+                        : null;
+                    const cellDefinition = {
+                        type: 'text',
+                        rawValue: value,
+                        displayValue: value,
+                        alignment: 'center-right'
+                    };
+                    if (meta && typeof meta === 'object') {
+                        const keys = Object.keys(meta);
+                        if (keys.length) {
+                            cellDefinition.data = {};
+                            for (let keyIndex = 0; keyIndex < keys.length; keyIndex++) {
+                                const metaKey = keys[keyIndex];
+                                cellDefinition.data[metaKey] = meta[metaKey];
+                            }
+                        }
+                    }
+                    cellsForRow.push(cellDefinition);
+                }
+
+                return {index: index, cells: cellsForRow};
+            });
+
+            return {columns: columns, content: content};
+        } catch (error) {
+            console.error('Utils.transformMdxResponseToGridTableLight: unexpected error while transforming MDX response.', error);
+            return emptyResult;
+        }
+    },
     extCall(fnName, ...args) {
         return ExtensionFunctions.call(fnName, ...args);
     }

--- a/analogic/static/assets/js/widgets/grid-table-light/grid-table-light.js
+++ b/analogic/static/assets/js/widgets/grid-table-light/grid-table-light.js
@@ -324,6 +324,9 @@ class GridTableLightWidget extends Widget {
         normalized.type = normalized.type || 'text';
         const hasDisplayValue = Object.prototype.hasOwnProperty.call(normalized, 'displayValue');
         const hasRawValue = Object.prototype.hasOwnProperty.call(normalized, 'rawValue');
+        if (!Object.prototype.hasOwnProperty.call(normalized, 'data')) {
+            normalized.data = {};
+        }
         if (!hasRawValue) {
             if (Object.prototype.hasOwnProperty.call(normalized, 'value')) {
                 normalized.rawValue = normalized.value;

--- a/apps/helloanalogic/static/assets/js/configs/repository.js
+++ b/apps/helloanalogic/static/assets/js/configs/repository.js
@@ -1,4 +1,4 @@
-/* global app, Utils, Api, v */
+/* global app, Utils, Api, v, RestRequest */
 
 'use strict';
 
@@ -218,6 +218,36 @@ Repository = {
                 body: recordLabel ? `${recordLabel} assigned to ${newValue}` : `${rowText} assigned to ${newValue}`
             });
             Api.updateContent('gridTableLightDemoInfoText');
+        }
+    },
+    gridTableLightServerTable: {
+        init() {
+            return new RestRequest(this.request);
+        },
+        request: {
+            url: () => '/api/v1/ExecuteMDX?$expand=Cells($select=Ordinal,FormattedValue;$expand=Members($select=Name, Attributes/Editable))',
+            type: 'POST',
+            server: true,
+            body: () => ({
+                key: 'safariAssetRegister2_mdx'
+            }),
+            parsingControl: {
+                type: 'script',
+                script: (data) => {
+                    const transformed = Utils.transformMdxResponseToGridTableLight(data, {rowTitle: 'Entity'});
+                    if (0 === transformed.columns.length && 0 === transformed.content.length) {
+                        console.error('gridTableLightServerTable: the MDX response could not be transformed into table data.');
+                        return transformed;
+                    }
+
+                    return Object.assign({
+                        freezeHeader: true,
+                        allowCopyToClipBoard: true,
+                        enableExport: true,
+                        exportConfig: {fileName: 'safari-asset-register.xlsx'}
+                    }, transformed);
+                }
+            }
         }
     },
     gridTableLightColumnCountSelector: {

--- a/apps/helloanalogic/static/assets/js/configs/widget-config.js
+++ b/apps/helloanalogic/static/assets/js/configs/widget-config.js
@@ -6498,6 +6498,27 @@ WidgetConfig = {
                                     ]
                                 }
                             ]
+                        },
+                        {
+                            id: 'gridTableLightDemoServerTableRow',
+                            type: GridRowWidget,
+                            width: '100%',
+                            marginTop: '24',
+                            widgets: [
+                                {
+                                    id: 'gridTableLightDemoServerTableCell',
+                                    type: GridCellWidget,
+                                    alignment: 'top-left',
+                                    width: '100%',
+                                    widgets: [
+                                        {
+                                            id: 'gridTableLightServerTable',
+                                            type: GridTableLightWidget,
+                                            skin: 'gridTableLightDemo'
+                                        }
+                                    ]
+                                }
+                            ]
                         }
                     ]
                 }


### PR DESCRIPTION
## Summary
- extend the MDX-to-GridTableLight transformer to capture Ordinal metadata for each cell and attach it to the generated rows
- ensure GridTableLight cells always expose a `data` object so optional metadata is available to consumers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d64823c450832b89157d1f1c7a492f