### PR TITLE
Rename analogic table widget assets to grid table plus

### DIFF
--- a/analogic/static/assets/css/widgets/grid-table-plus.css
+++ b/analogic/static/assets/css/widgets/grid-table-plus.css
@@ -1,20 +1,20 @@
-.ks-analogic-table {
+.ks-grid-table-plus {
     width: 100%;
     display: block;
 }
 
-.ks-analogic-table .ks-analogic-table-inner {
+.ks-grid-table-plus .ks-grid-table-plus-inner {
     width: 100%;
     overflow-x: auto;
 }
 
-.ks-analogic-table h3 {
+.ks-grid-table-plus h3 {
     margin: 0 0 8px;
     font-size: 16px;
     font-weight: 600;
 }
 
-.ks-analogic-table .tabulator {
+.ks-grid-table-plus .tabulator {
     border: none;
     background: transparent;
     font-family: inherit;
@@ -23,42 +23,42 @@
     color: #111827;
 }
 
-.ks-analogic-table .tabulator .tabulator-header {
+.ks-grid-table-plus .tabulator .tabulator-header {
     border-bottom: 1px solid #d1d5db;
     background-color: transparent;
 }
 
-.ks-analogic-table .tabulator .tabulator-header .tabulator-col {
+.ks-grid-table-plus .tabulator .tabulator-header .tabulator-col {
     background-color: #f3f4f6;
     color: #111827;
     border-right: 1px solid #e5e7eb;
     font-weight: 600;
 }
 
-.ks-analogic-table .tabulator .tabulator-header .tabulator-col:last-child {
+.ks-grid-table-plus .tabulator .tabulator-header .tabulator-col:last-child {
     border-right: none;
 }
 
-.ks-analogic-table .tabulator .tabulator-tableholder {
+.ks-grid-table-plus .tabulator .tabulator-tableholder {
     overflow-x: auto;
 }
 
-.ks-analogic-table .tabulator .tabulator-tableholder .tabulator-table {
+.ks-grid-table-plus .tabulator .tabulator-tableholder .tabulator-table {
     background-color: #ffffff;
 }
 
-.ks-analogic-table .tabulator .tabulator-row {
+.ks-grid-table-plus .tabulator .tabulator-row {
     border-bottom: 1px solid #e5e7eb;
 }
 
-.ks-analogic-table .tabulator .tabulator-row:nth-child(even) {
+.ks-grid-table-plus .tabulator .tabulator-row:nth-child(even) {
     background-color: #f9fafb;
 }
 
-.ks-analogic-table .tabulator .tabulator-row .tabulator-cell {
+.ks-grid-table-plus .tabulator .tabulator-row .tabulator-cell {
     border-right: 1px solid #e5e7eb;
 }
 
-.ks-analogic-table .tabulator .tabulator-row .tabulator-cell:last-child {
+.ks-grid-table-plus .tabulator .tabulator-row .tabulator-cell:last-child {
     border-right: none;
 }

--- a/analogic/static/assets/js/framework/utils.js
+++ b/analogic/static/assets/js/framework/utils.js
@@ -552,7 +552,7 @@ const Utils = {
             return;
         }
 
-        if (widgetInstance && widgetInstance.isAnalogicTableWidget) {
+        if (widgetInstance && widgetInstance.isGridTablePlusWidget) {
             for (i = 0; i < cellData.length; ++i) {
                 const row = cellData[i] || [];
                 const cell = row[col];

--- a/analogic/static/assets/js/widgets/grid-table-plus/grid-table-plus.js
+++ b/analogic/static/assets/js/widgets/grid-table-plus/grid-table-plus.js
@@ -2,11 +2,11 @@
 
 'use strict';
 
-class AnalogicTableWidget extends Widget {
+class GridTablePlusWidget extends Widget {
 
     constructor(options) {
         super(options);
-        this.isAnalogicTableWidget = true;
+        this.isGridTablePlusWidget = true;
         this.boundTabulatorHandlers = [];
         this.reset();
     }
@@ -35,7 +35,7 @@ class AnalogicTableWidget extends Widget {
     }
 
     getCssPrefix() {
-        return 'ks-analogic-table';
+        return 'ks-grid-table-plus';
     }
 
     getParameters(data) {
@@ -246,7 +246,7 @@ class AnalogicTableWidget extends Widget {
             try {
                 rowComponent = cellComponent.getRow();
             } catch (error) {
-                console.warn('AnalogicTableWidget: unable to resolve row from cell component', error);
+                console.warn('GridTablePlusWidget: unable to resolve row from cell component', error);
             }
         }
 
@@ -255,7 +255,7 @@ class AnalogicTableWidget extends Widget {
             try {
                 rowData = rowComponent.getData();
             } catch (error) {
-                console.warn('AnalogicTableWidget: unable to access row data from row component', error);
+                console.warn('GridTablePlusWidget: unable to access row data from row component', error);
             }
         }
 
@@ -275,7 +275,7 @@ class AnalogicTableWidget extends Widget {
                     rowIndex = index;
                 }
             } catch (error) {
-                console.warn('AnalogicTableWidget: unable to resolve row index from row component', error);
+                console.warn('GridTablePlusWidget: unable to resolve row index from row component', error);
             }
         }
 
@@ -293,7 +293,7 @@ class AnalogicTableWidget extends Widget {
                 try {
                     return cellComponent.getElement();
                 } catch (error) {
-                    console.warn('AnalogicTableWidget: unable to resolve cell element while locating metadata', error);
+                    console.warn('GridTablePlusWidget: unable to resolve cell element while locating metadata', error);
                     return null;
                 }
             })() : null;
@@ -345,7 +345,7 @@ class AnalogicTableWidget extends Widget {
 
     getHtml(widgetHtmls, processedData) {
         const definition = this.prepareTabulatorSetup(processedData || {});
-        const classes = ['ks-analogic-table', `ks-analogic-table-${definition.parameters.skin || 'standard'}`];
+        const classes = ['ks-grid-table-plus', `ks-grid-table-plus-${definition.parameters.skin || 'standard'}`];
         const styles = this.getGeneralStyles(processedData);
         if (definition.parameters.hideIfNoData && definition.data.length === 0) {
             styles.push('display:none;');
@@ -359,7 +359,7 @@ class AnalogicTableWidget extends Widget {
         const containerId = `${this.id}__tabulator`;
         return `<div class="${classes.join(' ')}" style="${styles.join('')}">
     ${this.options.title ? `<h3>${this.options.title}</h3>` : ''}
-    <div class="ks-analogic-table-inner">
+    <div class="ks-grid-table-plus-inner">
         <div class="analogic-tabulator" id="${containerId}"></div>
     </div>
 </div>`;
@@ -382,7 +382,7 @@ class AnalogicTableWidget extends Widget {
         container.innerHTML = '';
 
         if (typeof Tabulator === 'undefined') {
-            console.warn('Tabulator library is not available. AnalogicTableWidget cannot initialize.');
+            console.warn('Tabulator library is not available. GridTablePlusWidget cannot initialize.');
             return;
         }
 
@@ -488,7 +488,7 @@ class AnalogicTableWidget extends Widget {
             try {
                 rowComponent = cellComponent.getRow();
             } catch (error) {
-                console.warn('AnalogicTableWidget: unable to resolve row component from cell', error);
+                console.warn('GridTablePlusWidget: unable to resolve row component from cell', error);
             }
         }
         let columnComponent = this.extractColumnComponent(args);
@@ -496,7 +496,7 @@ class AnalogicTableWidget extends Widget {
             try {
                 columnComponent = cellComponent.getColumn();
             } catch (error) {
-                console.warn('AnalogicTableWidget: unable to resolve column component from cell', error);
+                console.warn('GridTablePlusWidget: unable to resolve column component from cell', error);
             }
         }
         const cellData = this.getCellFromTabulatorCell(cellComponent);
@@ -603,7 +603,7 @@ class AnalogicTableWidget extends Widget {
                 return element.innerHTML;
             }
         } catch (error) {
-            console.warn('AnalogicTableWidget: unable to resolve cell element while syncing metadata', error);
+            console.warn('GridTablePlusWidget: unable to resolve cell element while syncing metadata', error);
         }
         return undefined;
     }
@@ -627,7 +627,7 @@ class AnalogicTableWidget extends Widget {
             try {
                 value = cellComponent.getValue();
             } catch (error) {
-                console.warn('AnalogicTableWidget: unable to resolve cell value while syncing metadata', error);
+                console.warn('GridTablePlusWidget: unable to resolve cell value while syncing metadata', error);
             }
         }
 
@@ -685,7 +685,7 @@ class AnalogicTableWidget extends Widget {
                     element.innerHTML = displayValue;
                 }
             } catch (error) {
-                console.warn('AnalogicTableWidget: unable to update cell element while syncing metadata', error);
+                console.warn('GridTablePlusWidget: unable to update cell element while syncing metadata', error);
             }
         }
     }
@@ -820,7 +820,7 @@ class AnalogicTableWidget extends Widget {
     updateHtml(data) {
         const definition = this.tabulatorDefinition || this.prepareTabulatorSetup(data || {});
         const section = $('#' + this.id);
-        const main = section.find('.ks-analogic-table').first();
+        const main = section.find('.ks-grid-table-plus').first();
         if (!main.length) {
             return;
         }

--- a/analogic/templates/css.html
+++ b/analogic/templates/css.html
@@ -1,6 +1,6 @@
 <link href="{{url_for('static', filename='assets/css/bootstrap-grid.min.css')}}?v={{cnf.version}}" rel="stylesheet" type="text/css">
 <link href="{{url_for('static', filename='assets/css/widgets/loader.css')}}?v={{cnf.version}}" rel="stylesheet" type="text/css">
-<link href="{{url_for('static', filename='assets/css/widgets/analogic-table.css')}}?v={{cnf.version}}" rel="stylesheet" type="text/css">
+<link href="{{url_for('static', filename='assets/css/widgets/grid-table-plus.css')}}?v={{cnf.version}}" rel="stylesheet" type="text/css">
 <link href="{{url_for('static', filename='assets/css/widgets/simulation-panel-slider.css')}}?v={{cnf.version}}" rel="stylesheet" type="text/css">
 <link href="{{url_for('static', filename='assets/css/lib/Chart-2.9.3.min.css')}}?v={{cnf.version}}" rel="stylesheet" type="text/css">
 <link href="{{url_for('static', filename='assets/css/lib/nouislider.min.css')}}?v={{cnf.version}}" rel="stylesheet" type="text/css">

--- a/analogic/templates/javascripts.html
+++ b/analogic/templates/javascripts.html
@@ -78,7 +78,7 @@
 <script src="{{ url_for('static', filename='assets/js/widgets/grid-table/grid-table-cell.js') }}?v={{ cnf.version }}"></script>
 <script src="{{ url_for('static', filename='assets/js/widgets/grid-table/grid-table-header-row.js') }}?v={{ cnf.version }}"></script>
 <script src="{{ url_for('static', filename='assets/js/widgets/grid-table/grid-table-header-cell.js') }}?v={{ cnf.version }}"></script>
-<script src="{{ url_for('static', filename='assets/js/widgets/analogic-table/analogic-table.js') }}?v={{ cnf.version }}"></script>
+<script src="{{ url_for('static', filename='assets/js/widgets/grid-table-plus/grid-table-plus.js') }}?v={{ cnf.version }}"></script>
 <script src="{{ url_for('static', filename='assets/js/widgets/grid-table-light/grid-table-light.js') }}?v={{ cnf.version }}"></script>
 <script src="{{ url_for('static', filename='assets/js/widgets/button.js') }}?v={{ cnf.version }}"></script>
 <script src="{{ url_for('static', filename='assets/js/widgets/text.js') }}?v={{ cnf.version }}"></script>

--- a/apps/helloanalogic/static/assets/js/configs/repository.js
+++ b/apps/helloanalogic/static/assets/js/configs/repository.js
@@ -793,8 +793,8 @@ Repository = {
                 }
             ];
             const actionButtons = (code) => `<div style="display:flex;gap:6px;justify-content:center;">
-    <button class="analogic-table-demo__action-button" data-action="details" data-project="${code}" style="padding:6px 12px;border-radius:6px;border:1px solid #CBD5E1;background:#FFFFFF;color:#1E293B;font-weight:600;cursor:pointer;">Details</button>
-    <button class="analogic-table-demo__action-button analogic-table-demo__action-button--primary" data-action="focus" data-project="${code}" style="padding:6px 12px;border-radius:6px;border:none;background:#2563EB;color:#FFFFFF;font-weight:600;cursor:pointer;">Focus</button>
+    <button class="grid-table-plus-demo__action-button" data-action="details" data-project="${code}" style="padding:6px 12px;border-radius:6px;border:1px solid #CBD5E1;background:#FFFFFF;color:#1E293B;font-weight:600;cursor:pointer;">Details</button>
+    <button class="grid-table-plus-demo__action-button grid-table-plus-demo__action-button--primary" data-action="focus" data-project="${code}" style="padding:6px 12px;border-radius:6px;border:none;background:#2563EB;color:#FFFFFF;font-weight:600;cursor:pointer;">Focus</button>
 </div>`;
             const columns = [
                 {
@@ -994,13 +994,13 @@ Repository = {
                         action(e, row) {
                             const data = row.getData().__analogicCells || {};
                             const project = data.project ? data.project.value : 'Unknown project';
-                            console.log('[AnalogicTableDemo] context menu -> focus project', project);
+                            console.log('[GridTablePlusDemo] context menu -> focus project', project);
                         }
                     },
                     {
                         label: 'Log raw row data',
                         action(e, row) {
-                            console.log('[AnalogicTableDemo] context menu -> row data', row.getData());
+                            console.log('[GridTablePlusDemo] context menu -> row data', row.getData());
                         }
                     }
                 ],
@@ -1021,7 +1021,7 @@ Repository = {
         tableBuilt(ctx) {
             const table = ctx.getTabulator();
             const rowCount = table && typeof table.getData === 'function' ? table.getData().length : 0;
-            console.log('[AnalogicTableDemo] table built with', rowCount, 'rows');
+            console.log('[GridTablePlusDemo] table built with', rowCount, 'rows');
         },
         selectionChanged(ctx, data) {
             const selected = Array.isArray(data) ? data.map((item) => {
@@ -1030,21 +1030,21 @@ Repository = {
                 }
                 return item && item.project ? item.project : '';
             }).filter(Boolean) : [];
-            console.log('[AnalogicTableDemo] selection changed:', selected);
+            console.log('[GridTablePlusDemo] selection changed:', selected);
         },
         cellClicked(ctx, event) {
             const rowComponent = ctx.getRowComponent();
             const cells = rowComponent && typeof rowComponent.getData === 'function' ? rowComponent.getData().__analogicCells : null;
             const projectName = cells && cells.project ? cells.project.value : 'Unknown project';
-            if (event && event.target && event.target.classList && event.target.classList.contains('analogic-table-demo__action-button')) {
+            if (event && event.target && event.target.classList && event.target.classList.contains('grid-table-plus-demo__action-button')) {
                 const action = event.target.getAttribute('data-action') || 'action';
-                console.log(`[AnalogicTableDemo] ${action} button clicked for ${projectName}`);
+                console.log(`[GridTablePlusDemo] ${action} button clicked for ${projectName}`);
                 event.stopPropagation();
                 return;
             }
             const meta = ctx.getCell();
             const field = meta ? meta.field : 'n/a';
-            console.log('[AnalogicTableDemo] cell click ->', field, 'value:', meta ? meta.value : undefined, 'project:', projectName);
+            console.log('[GridTablePlusDemo] cell click ->', field, 'value:', meta ? meta.value : undefined, 'project:', projectName);
         },
         cellEdited(ctx) {
             const meta = ctx.getCell();
@@ -1058,7 +1058,7 @@ Repository = {
                     meta.value = updatedValue;
                     meta.displayValue = updatedValue;
                 }
-                console.log('[AnalogicTableDemo] cell edited ->', meta.field, 'is now', meta.value, 'for', projectName);
+                console.log('[GridTablePlusDemo] cell edited ->', meta.field, 'is now', meta.value, 'for', projectName);
             }
         }
     },
@@ -1275,7 +1275,7 @@ Repository = {
                 };
             }
 
-            console.log('[AnalogicTableSimpleDemo] cell edited', {
+            console.log('[GridTablePlusSimpleDemo] cell edited', {
                 field: meta.field || (typeof ctx.getColumnField === 'function' ? ctx.getColumnField() : undefined),
                 ordinal: ordinal,
                 value: updatedValue

--- a/apps/helloanalogic/static/assets/js/configs/widget-config.js
+++ b/apps/helloanalogic/static/assets/js/configs/widget-config.js
@@ -6448,7 +6448,7 @@ WidgetConfig = {
                                             id: 'analogicTableDemoHeaderInfo',
                                             type: TextWidget,
                                             title: 'Tabulator v6 Demo',
-                                            body: 'Live inside AnalogicTableWidget',
+                                            body: 'Live inside GridTablePlusWidget',
                                             skin: 'menu',
                                             titleFontSize: 16,
                                             bodyFontColor: '#4F5B66'
@@ -6470,7 +6470,7 @@ WidgetConfig = {
                                     widgets: [
                                         {
                                             id: 'analogicTableDemoTable',
-                                            type: AnalogicTableWidget,
+                                            type: GridTablePlusWidget,
                                             title: 'Project Portfolio Overview',
                                             minWidth: 960,
                                             hideIfNoData: false,
@@ -6528,7 +6528,7 @@ WidgetConfig = {
                                     widgets: [
                                         {
                                             id: 'analogicTableDemoSimpleTable',
-                                            type: AnalogicTableWidget,
+                                            type: GridTablePlusWidget,
                                             title: 'Editable Data Grid',
                                             minWidth: 960,
                                             hideIfNoData: false,


### PR DESCRIPTION
## Summary
- move the Tabulator widget assets into a `grid-table-plus` directory and update the script/css template references
- align the widget markup with the new `ks-grid-table-plus` prefix so the stylesheet and runtime share the same naming
- refresh the helloanalogic demo helper classes to reference the renamed GridTablePlus action buttons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbb5ad0d60832ba6c76d7ea6fc723b