### PR TITLE
Normalize documentation punctuation to ASCII

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The framework consists of the following main parts:
 
 1. #### JS Frontend framework
 
-The frontend framework is in essence a collection of JavaScript elements called “widgets”.  [Widgets](https://analogic-framework.readthedocs.io/en/latest/widgets) are the main building blocks of the applications built using the Analogic Framework. Every element in the final application UI is always an instance of a widget. Some widgets are very simple both in appearance and function (eg. a Button widget or a Text widget) some can be complex and can contain other widgets (e.g. a GridTable widget). The widgets usually communicate directly with the Planning Analytics database using REST API calls sending MDX queries as requests and getting JSONs as responses.
+The frontend framework is in essence a collection of JavaScript elements called "widgets".  [Widgets](https://analogic-framework.readthedocs.io/en/latest/widgets) are the main building blocks of the applications built using the Analogic Framework. Every element in the final application UI is always an instance of a widget. Some widgets are very simple both in appearance and function (eg. a Button widget or a Text widget) some can be complex and can contain other widgets (e.g. a GridTable widget). The widgets usually communicate directly with the Planning Analytics database using REST API calls sending MDX queries as requests and getting JSONs as responses.
 
 2. #### Python middleware
 

--- a/apps/helloanalogic/static/assets/js/configs/repository.js
+++ b/apps/helloanalogic/static/assets/js/configs/repository.js
@@ -181,7 +181,7 @@ Repository = {
             const rowLabel = rowNumber ? `row ${rowNumber}` : 'selected row';
             Utils.setWidgetValue('gridTableLightDemoLastAction', {
                 title: 'Details requested',
-                body: recordLabel ? `${recordLabel} – ${rowLabel}` : `Details requested for ${rowLabel}`
+                body: recordLabel ? `${recordLabel} - ${rowLabel}` : `Details requested for ${rowLabel}`
             });
             Api.updateContent('gridTableLightDemoInfoText');
         },

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -11,7 +11,7 @@ This guide explains how to create and configure a SharePoint upload widget in th
 
 The SharePoint widget consists of two main components:
 
-#. **Backend endpoints** provided by the ``analogic_sharepoint.sharepoint_endpoints`` module. These handle upload and download requests and decide—based on the ``_share_points`` configuration—whether to use SharePoint, UNC, or local storage. See ``analogic_sharepoint/sharepoint_endpoints.py``.
+#. **Backend endpoints** provided by the ``analogic_sharepoint.sharepoint_endpoints`` module. These handle upload and download requests and decide based on the ``_share_points`` configuration whether to use SharePoint, UNC, or local storage. See ``analogic_sharepoint/sharepoint_endpoints.py``.
 #. **Frontend widget and controller logic** located in ``static/assets/js/sharepoint-upload-widget.js`` and ``static/assets/js/sharepoint-upload.js``. The widget loads files into a ``FormData`` object, handles rendering, and triggers events.
 
 2. Folder Structure
@@ -37,10 +37,10 @@ Create (or copy) the following folder structure under your application. A workin
            └── skin/
                └── css/
 
-* ``app.json`` – global configuration for the application.
-* ``static/assets/js/configs/widget-config.js`` – registers widgets on the page.
-* ``static/assets/js/configs/repository.js`` – repository-specific logic (for example, triggering uploads).
-* ``server/configs/repository.yml`` – configuration for TM1/backend processes and permissions.
+* ``app.json`` - global configuration for the application.
+* ``static/assets/js/configs/widget-config.js`` - registers widgets on the page.
+* ``static/assets/js/configs/repository.js`` - repository-specific logic (for example, triggering uploads).
+* ``server/configs/repository.yml`` - configuration for TM1/backend processes and permissions.
 
 3. Configuring ``app.json``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -77,15 +77,15 @@ The ``app.json`` file stores all connection profiles under the ``_share_points``
 3.1 Required Keys
 ^^^^^^^^^^^^^^^^^
 
-* ``url`` – the SharePoint site URL, UNC path, or local directory root.
-* ``type`` – connection type (``Sharepoint``, ``UNC``, or ``Local``).
-* ``folder`` – for SharePoint connections, the document library name; optional for UNC (it can be part of the path); for local connections, the target folder or path.
+* ``url`` - the SharePoint site URL, UNC path, or local directory root.
+* ``type`` - connection type (``Sharepoint``, ``UNC``, or ``Local``).
+* ``folder`` - for SharePoint connections, the document library name; optional for UNC (it can be part of the path); for local connections, the target folder or path.
 
 3.2 Optional Keys
 ^^^^^^^^^^^^^^^^^
 
-* ``client`` and ``secret`` – application-level credentials for SharePoint or network credentials for UNC. The ``secret`` can be omitted if it is stored in the Analogic environment keyring under the ``analogic_sharepoint_{instance}/{identifier}`` key; in that case the backend loads the password automatically.
-* ``disable_call_process`` – when set to ``true``, the upload skips calling a TM1 process (only the file is stored).
+* ``client`` and ``secret`` - application-level credentials for SharePoint or network credentials for UNC. The ``secret`` can be omitted if it is stored in the Analogic environment keyring under the ``analogic_sharepoint_{instance}/{identifier}`` key; in that case the backend loads the password automatically.
+* ``disable_call_process`` - when set to ``true``, the upload skips calling a TM1 process (only the file is stored).
 
 3.3 Required Request Parameters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -138,14 +138,14 @@ Register the widget in ``widget-config.js``. At minimum you need an upload widge
        label: 'Upload'
    }
 
-The widget supports various visual and behavioural options (for example, ``label``, ``icon``, ``maxFileSize``, ``convertXlsxToCsv``). The full list is at the beginning of the ``SharePointUploadWidget`` class’s ``getHtml`` method.
+The widget supports various visual and behavioural options (for example, ``label``, ``icon``, ``maxFileSize``, ``convertXlsxToCsv``). The full list is at the beginning of the ``SharePointUploadWidget`` class's ``getHtml`` method.
 
 5.2 Repository Logic
 ^^^^^^^^^^^^^^^^^^^^
 
 The ``Repository.spUp.sharepointUpload`` function selects which ``_share_points`` connection the widget should use. You can also return additional fields in the object for the upload (for example, parameters for the TM1 process).
 
-The ``Repository.doUpload.launch`` method triggers the widget’s ``sharepointUpload`` event on button click, starting the actual upload.
+The ``Repository.doUpload.launch`` method triggers the widget's ``sharepointUpload`` event on button click, starting the actual upload.
 
 5.3 Event Handling and Feedback
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -159,19 +159,19 @@ The ``Repository.doUpload.launch`` method triggers the widget’s ``sharepointUp
 
 To download a file, send a GET request to the ``sharepoint/download`` endpoint with the following parameters:
 
-* ``share_point_id`` – key under ``_share_points``.
-* ``displayName`` – file name shown to the user.
-* ``uniqueName`` – unique file name on storage (returned to you during upload).
+* ``share_point_id`` - key under ``_share_points``.
+* ``displayName`` - file name shown to the user.
+* ``uniqueName`` - unique file name on storage (returned to you during upload).
 
 The backend automatically fetches the file from the correct storage based on the connection type.
 
 7. Tips and Troubleshooting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* **Handling credentials** – if you do not want to store ``secret`` in ``app.json``, use the system keyring. The module automatically reads it when only ``client`` is present in ``app.json``.
-* **Maximum file size** – the ``maxFileSize`` option is interpreted in MB. If the total size of the selected files exceeds the limit, the widget raises an error and does not send the files.
-* **Excel → CSV conversion** – set ``convertXlsxToCsv: true`` to convert ``.xlsx`` files to CSV before upload. The backend performs the conversion using the ``openpyxl`` and ``csv`` modules.
-* **Loader behaviour** – if additional asynchronous work should continue after the upload, set ``skipStoppingTheLoaderAfterSuccessUpload: true`` so the loader stays visible.
+* **Handling credentials** - if you do not want to store ``secret`` in ``app.json``, use the system keyring. The module automatically reads it when only ``client`` is present in ``app.json``.
+* **Maximum file size** - the ``maxFileSize`` option is interpreted in MB. If the total size of the selected files exceeds the limit, the widget raises an error and does not send the files.
+* **Excel -> CSV conversion** - set ``convertXlsxToCsv: true`` to convert ``.xlsx`` files to CSV before upload. The backend performs the conversion using the ``openpyxl`` and ``csv`` modules.
+* **Loader behaviour** - if additional asynchronous work should continue after the upload, set ``skipStoppingTheLoaderAfterSuccessUpload: true`` so the loader stays visible.
 
 8. Summary Steps
 ~~~~~~~~~~~~~~~~

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -11,7 +11,7 @@ The framework consists of two main parts
       :name: js-frontend-framework
 
    The frontend framework is in essence a collection of JavaScript
-   elements called “widgets”. Widgets are the main building blocks of
+   elements called "widgets". Widgets are the main building blocks of
    the applications built using the Analogic Framework. Every element in
    the final application UI is always an instance of a widget. Some
    widgets are very simple both in appearance and function (eg. a Button
@@ -94,7 +94,7 @@ Running from code
 Using pip
 ~~~~~~~~~
 
-1. Create a folder where analogic’s root will be. e.g:
+1. Create a folder where analogic's root will be. e.g:
 
    yourpath/analogicroot
 
@@ -142,10 +142,10 @@ Using pip
    .. rubric:: Hello world app
       :name: hello-world-app
 
-   -  create a “default” folder in apps folder.
+   -  create a "default" folder in apps folder.
    -  download and unzip
       `this <https://github.com/KnowledgeSeed/analogic/blob/main/app_structure.zip>`__
-      into “default” folder
+      into "default" folder
 
    or
 
@@ -203,7 +203,7 @@ framework. This application indents to demonstrate the Web UI features
 without needing to install and hook up with a TM1 server.
 
 There are some sample ``docker-compose`` recipes provided in this
-repository to begin with. It’s important to note that these are
+repository to begin with. It's important to note that these are
 considered samples and patterns. Your deployment setup might require
 further customizations or extensions.
 

--- a/docs/source/widget_events.rst
+++ b/docs/source/widget_events.rst
@@ -56,8 +56,8 @@ into a ``perform`` action. The widget markup wires the inner container to the
 icon event, while the runtime registers editable/performable behaviour based on
 those flags.
 
-Repository ``perform`` handlers let you centralise complex cascades—such as
-resetting filters or triggering shared logic—without duplicating code across
+Repository ``perform`` handlers let you centralise complex cascades such as
+resetting filters or triggering shared logic without duplicating code across
 multiple cells.
 
 TextBoxWidget

--- a/docs/source/widgets.rst
+++ b/docs/source/widgets.rst
@@ -208,8 +208,8 @@ Configuration
    grid lines draw ticks
 - xAxesGridLinesColor\ **:** color of the x axes grid lines
 - xAxesTicksFontSize\ **:** size of the x axes ticks
-- xAxesTicksFontFamily\ **:** string, default ‘imago, sans-serif’
-- xAxesTicksFontStyle\ **:** string, default ‘bold’
+- xAxesTicksFontFamily\ **:** string, default 'imago, sans-serif'
+- xAxesTicksFontStyle\ **:** string, default 'bold'
 - xAxesTicksFontColor\ **:** color of the x axes ticks
 - xAxesTicksPadding\ **:** padding between X axes ticks
 - xAxesTicksOffset:
@@ -638,8 +638,8 @@ Configuration
 - type\ **:** type of widget
 - action\ **:** executed action. currently choose only (only action is
    delete)
-- deleteMessage\ **:** ‘Are you sure to clear all data of this
-   product?’
+- deleteMessage\ **:** 'Are you sure to clear all data of this
+   product?'
 - align\ **:** left or right side of horizontal table
 - position\ **:** position of widget in horizontal table
 
@@ -936,7 +936,7 @@ Configuration
 - listen: {event, method} events for the widget listen to and method to
    do
 - skin: Selected skin of widget
-- widgets: [{id: ‘tab1name’,label: ‘text’,action: ‘text’,selected:
+- widgets: [{id: 'tab1name',label: 'text',action: 'text',selected:
    true},…
 
 TM1 integration
@@ -1892,8 +1892,8 @@ Configuration
    grid lines drow border
 - xAxesGridLinesColor\ **:** color of the x axes grid lines
 - xAxesTicksFontSize\ **:** size of the x axes ticks
-- xAxesTicksFontFamily\ **:** string, default ‘imago, sans-serif’
-- xAxesTicksFontStyle\ **:** string, default ‘bold’
+- xAxesTicksFontFamily\ **:** string, default 'imago, sans-serif'
+- xAxesTicksFontStyle\ **:** string, default 'bold'
 - xAxesTicksFontColor\ **:** color of the x axes ticks
 - xAxesTicksPadding\ **:** padding between X axes ticks
 - xAxesLabelDisplay\ **:**  true or false, display the x axes label
@@ -2450,8 +2450,8 @@ Configuration
 ~~~~~~~~~~~~~
 
 - id\ **:** Widget Id which used for reference in framework
-- selectorTreeColNames: [‘Dimensions’, ‘Hierarchies’, ‘Subsets’,
-   ‘Elements’]
+- selectorTreeColNames: ['Dimensions', 'Hierarchies', 'Subsets',
+   'Elements']
 - colors:
 - data:
 - presetData:
@@ -2731,7 +2731,7 @@ Repository behaviour
 
 Data repository specifics (Comment functionality working with 2 special
 event commentEdit and commentShow, these events transfer the clicked
-scroll table row information to the comment container’s widgets).
+scroll table row information to the comment container's widgets).
 
 
 SegmentedBarWidget
@@ -2789,7 +2789,7 @@ Configuration
 - id\ **:** Widget Id which used for reference in framework
 - type\ **:** Type of Widget
 - skin: Selected skin of widget
-- value\ **:**  ‘1’ if the default value is ON, and ‘0’ if the default
+- value\ **:**  '1' if the default value is ON, and '0' if the default
    vaule is OFF
 - label\ **:** Label of the widget
 - action\ **:** Action of Segmented Control Item (scroll, open or
@@ -3028,9 +3028,9 @@ Configuration
 - trackValueMagnifierLabelFontSize: size of the magnifier label font
 - value: default value of slider (can be array)
 - buttonsVisible: if buttons visible (flag)
-- legend: gives a description of each series. ([{name: ‘First Val’,
-   color: ‘red’}, {name: ‘Second Val’, color: ‘pink’}, {name: ‘Third
-   Val’, color: ‘orange’}])
+- legend: gives a description of each series. ([{name: 'First Val',
+   color: 'red'}, {name: 'Second Val', color: 'pink'}, {name: 'Third
+   Val', color: 'orange'}])
 - visible: if widget visible (flag)
 
 TM1 integration
@@ -3656,7 +3656,7 @@ Configuration
 - type: Type of Widget
 - action: action if button clicked, name of action in repository
 - confirmMessage: what confirm message should pop up
-- groupId: ID of the connected toggle’s, each toggle has to be refer to
+- groupId: ID of the connected toggle's, each toggle has to be refer to
    the same group naming
 - icon: selected icon of toggle when ON
 - iconOff: selected icon of toggle when OFF
@@ -3667,7 +3667,7 @@ Configuration
 - titleFontSize: size of the button label font
 - titleOff: title of OFF state
 - titleOn: title of ON state
-- **value: ‘1’ if the default value is ON, and ‘0’ if the default value
+- **value: '1' if the default value is ON, and '0' if the default value
    is OFF**
 - visible: if widget visible (flag)
 - width: width of the button (%), if hasLayout == true, default: 5
@@ -3872,7 +3872,7 @@ Configuration
 - listen: {event, method} events for the widget listen to and method to
    do
 - dataset\ **:** [{lineVisible: boolean, lineStyle:
-   ‘dotted’/’solid’/’dashed’, lineWidth: int, labelVisible: boolean,
+   'dotted'/'solid'/'dashed', lineWidth: int, labelVisible: boolean,
    titleVisible: int, value: float, label: string,  lineColor: string,
    labelColor: string, titleColor: string, titleBgColor: string},…]
 
@@ -3906,11 +3906,11 @@ Configuration
 
 - id\ **:** widget id which used for reference in framework
 - dataset1\ **:** $.extend(true, dataset1Config, d.dataset1 \|\|
-   {legendLabel: ‘Dataset One’, legendColor: ‘pink’, datapoints:
+   {legendLabel: 'Dataset One', legendColor: 'pink', datapoints:
    [{value: 9.06}, {value: -0.06}, {value: 0.5}, {value: 0}, {value:
    9.5}]})
 - dataset2\ **:** $.extend(true, dataset2Config, d.dataset2 \|\|
-   {legendLabel: ‘Dataset One’, legendColor: ‘red’, datapoints: [{value:
+   {legendLabel: 'Dataset One', legendColor: 'red', datapoints: [{value:
    8.06}, {value: -3.06}, {value: 1.5}, {value: 5}, {value: 4.5}]})
 - xAxisLabels\ **:** labels of the x-axis
 - labelVisible\ **:** if label visible (flag)


### PR DESCRIPTION
## Summary
- replace smart punctuation characters with ASCII equivalents across the README and documentation so the text renders correctly outside of UTF-8 aware editors
- update the SharePoint extension guide and sample repository configuration to avoid en/em dashes that showed up as artifacts in SharePoint exports

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4cfc21d608330972847f6406a3e8b